### PR TITLE
Added the "comprehensive" retrieval method to the processor tool

### DIFF
--- a/example/reagent-demo/src/acme/frontend/annotated.cljc
+++ b/example/reagent-demo/src/acme/frontend/annotated.cljc
@@ -1,12 +1,16 @@
-(ns acme.frontend.foobar
+(ns acme.frontend.annotated
   (:require [girouette.core :refer [css]]))
+
+;; -----------------------------------------------
+;;   Use {:retrieve :annotated} to collect those
+;; -----------------------------------------------
 
 (css "text-green-300")
 
 ;; This might be supported by the Girouette processor in a next version.
 #_ (css (str "text-" "red" "-300"))
 
-(defn simple-example []
+(defn annotated-example []
   [:h1 {:class (css "flex")}
    [:div {:class (css "flex-10")} "hello"]
    [:div {:class (css "flex-20")} "the"]

--- a/example/reagent-demo/src/acme/frontend/app.cljc
+++ b/example/reagent-demo/src/acme/frontend/app.cljc
@@ -8,13 +8,13 @@
 (defn simple-example []
   [:main
    ;; Demonstrates the use of arbitrary values in flex layouts
-   [:h1 {:class (css ["flex" "space-x-2"])}
-    [:div {:class (css ["flex-1" "p-4" "text-center" "rounded-lg" "bg-red-200"])} "hello"]
-    [:div {:class (css ["flex-2" "p-4" "text-center" "rounded-lg" "bg-green-200"])} "the"]
-    [:div {:class (css ["flex-9/3" "p-4" "text-center" "rounded-lg" "bg-blue-200"])} "world"]]
+   [:h1.flex.space-x-2
+    [:div.flex-1.p-4.text-center.rounded-lg.bg-red-200 "hello"]
+    [:div.flex-2.p-4.text-center.rounded-lg.bg-green-200 "the"]
+    [:div.p-4.text-center.rounded-lg.bg-blue-200 {:class "flex-9/3"} "world"]]
 
    ;; Demonstrates the use of a custom Girouette component which provides the CSS class "rainbow-text"
-   [:div {:class (css ["rainbow-text" "text-center" "font-size-10vw"])}
+   [:div.rainbow-text.text-center.font-size-10vw
     "Everybody needs a rainbow in their life"]])
 
 (defn render []

--- a/example/reagent-demo/src/acme/frontend/comprehensive.cljc
+++ b/example/reagent-demo/src/acme/frontend/comprehensive.cljc
@@ -1,0 +1,13 @@
+(ns acme.frontend.comprehensive
+  (:require [girouette.core :refer [css]]))
+
+;; ---------------------------------------------------
+;;   Use {:retrieve :comprehensive} to collect those
+;;   (it's the default retrieval method)
+;; ---------------------------------------------------
+
+(defn compact-example []
+  [:h1.flex
+   [:div.flex-1 "hello"]
+   [:div.flex-2 "the"]
+   [:div.flex-3 "world"]])


### PR DESCRIPTION
Added the "comprehensive" retrieval method to the processor tool.
It allows for a comprehensive collection of the css names at the expense of a lot of false positives.

Closes #43 