### PR TITLE
Add support for using symbols instead of strings or dot tags.

### DIFF
--- a/example/reagent-demo/src/acme/frontend/drop_in.cljc
+++ b/example/reagent-demo/src/acme/frontend/drop_in.cljc
@@ -1,0 +1,8 @@
+(ns acme.frontend.drop-in
+  (:require [girouette.core :refer [css]]))
+
+;; This proves that girouette
+;; can work as a drop-in replacement for tailwind.
+
+(defn drop-in-example []
+  [:h1 {:class '[text-5xl underline font-serif]}])

--- a/example/reagent-demo/src/acme/frontend/drop_in.cljc
+++ b/example/reagent-demo/src/acme/frontend/drop_in.cljc
@@ -6,3 +6,9 @@
 
 (defn drop-in-example []
   [:h1 {:class '[text-5xl underline font-serif]}])
+
+(defn compact-example []
+  [:h1.flex
+   [:div.flex-1 "hello"]
+   [:div.flex-2 "the"]
+   [:div.flex-3 "world"]])

--- a/example/reagent-demo/src/acme/frontend/drop_in.cljc
+++ b/example/reagent-demo/src/acme/frontend/drop_in.cljc
@@ -5,4 +5,4 @@
 ;; can work as a drop-in replacement for tailwind.
 
 (defn drop-in-example []
-  [:h1 {:class '[text-5xl underline font-serif]}])
+  [:h1 {:class '[text-5xl underline font-serif dark:text-gray-100]}])

--- a/example/reagent-demo/src/acme/frontend/drop_in.cljc
+++ b/example/reagent-demo/src/acme/frontend/drop_in.cljc
@@ -6,9 +6,3 @@
 
 (defn drop-in-example []
   [:h1 {:class '[text-5xl underline font-serif]}])
-
-(defn compact-example []
-  [:h1.flex
-   [:div.flex-1 "hello"]
-   [:div.flex-2 "the"]
-   [:div.flex-3 "world"]])

--- a/lib/processor/.gitignore
+++ b/lib/processor/.gitignore
@@ -6,3 +6,7 @@
 .cljs_node_repl
 node_modules
 out
+
+*~
+[#]*[#]
+.\#*

--- a/lib/processor/deps.edn
+++ b/lib/processor/deps.edn
@@ -9,7 +9,7 @@
 
         garden/garden {:mvn/version "1.3.10"}
         ;girouette/girouette {:local/root "../girouette"}
-        girouette/girouette {:mvn/version "0.0.2"}}
+        girouette/girouette {:mvn/version "0.0.3"}}
 
  :aliases {:test {:extra-paths ["test"]
                   :extra-deps  {lambdaisland/kaocha           {:mvn/version "1.0.641"}

--- a/lib/processor/deps.edn
+++ b/lib/processor/deps.edn
@@ -17,21 +17,21 @@
                                 lambdaisland/kaocha-junit-xml {:mvn/version "0.0.76"}
                                 org.clojure/test.check        {:mvn/version "1.1.0"}}}
 
-           ; clojure -M:outdated --write
+                                        ; clojure -M:outdated --write
            :outdated {:replace-deps {olical/depot {:mvn/version "2.1.0"}}
-                      :main-opts ["-m" "depot.outdated.main"]}
+                      :main-opts    ["-m" "depot.outdated.main"]}
 
            :reveal {:extra-deps {vlaaad/reveal {:mvn/version "1.3.194"}}
                     :ns-default vlaaad.reveal
-                    :exec-fn repl}
+                    :exec-fn    repl}
 
            :depstar {:replace-deps {seancorfield/depstar {:mvn/version "2.0.188"}}
-                     :exec-fn hf.depstar/jar
-                     :exec-args {:sync-pom true
-                                 :group-id "girouette"
-                                 :artifact-id "processor"
-                                 :version "0.0.2"
-                                 :jar "processor.jar"}}}}
+                     :exec-fn      hf.depstar/jar
+                     :exec-args    {:sync-pom    true
+                                    :group-id    "girouette"
+                                    :artifact-id "processor"
+                                    :version     "0.0.3"
+                                    :jar         "processor.jar"}}}}
 ;; Memo for deploying a new release:
 ;; - Change the version above, then build the jar:
 ;;     clojure -X:depstar

--- a/lib/processor/src/girouette/processor.clj
+++ b/lib/processor/src/girouette/processor.clj
@@ -44,18 +44,6 @@
     (stub-js-deps! s)
     s))
 
-;; mark1
-
-(defn- receive-type-hook [type hook-fn]
-  (let [hook-type {:keyword 'cljs.core/Keyword
-                   :string  'string
-                   :symbol  'cljs.core/Symbol}]
-    (fn [env ast opts]
-      (when (and (= (:op ast) :const)
-                 (= (:tag ast) (type hook-type)))
-        (hook-fn (-> ast :val)))
-      ast)))
-
 ;; (ana-api/analyze nil "hi")
 ;; (ana-api/analyze nil :hi)
 
@@ -65,8 +53,6 @@
                (= (-> ast :fn :name) qualified-symbol))
       (hook-fn (-> ast :form second)))
     ast))
-
-#_ (def type :string)
 
 (def receive-hook-fn
   {:keyword #(->> (name %)
@@ -81,9 +67,15 @@
     (let [names ((type receive-hook-fn) x)]
       (swap! css-classes into names))))
 
-(defn receive [type css-classes]
-  (receive-type-hook type
-                     (receive-utility type css-classes)))
+(defn- receive [type css-classes]
+  (let [hook-type {:keyword 'cljs.core/Keyword
+                   :string  'string
+                   :symbol  'cljs.core/Symbol}]
+    (fn [env ast opts]
+      (when (and (= (:op ast) :const)
+                 (= (:tag ast) (type hook-type)))
+        ((receive-utility type css-classes) (-> ast :val)))
+      ast)))
 
 (defn- gather-css-classes [file]
   (let [css-classes (atom #{})


### PR DESCRIPTION
```clojure
;; You can now write
[:tag {:class '[class-name another-class-name]} "content"]
;; As opposed to just
[:tag {:class '["class-name another-class-name"]} "content"]
;; Or
[:tag.class-name.another-class-name "content"]
```

There's also some refactoring that went into this. Feel free to cherry pick just from lines 61-62 in `processor.clj`.