### PR TITLE
added support for symbols

### DIFF
--- a/example/reagent-demo/src/acme/frontend/symbol_support.cljc
+++ b/example/reagent-demo/src/acme/frontend/symbol_support.cljc
@@ -1,0 +1,10 @@
+(ns acme.frontend.symbol-support
+  (:require [girouette.core :refer [css]]))
+
+;; This proves that symbols work as well.
+;; Symbols do not however work when there is a slash
+;; as it semantically indicates a namespace to the parser.
+;; `[:tag {class: '[property-n/n]}]` will fail.
+
+(defn symbol-example []
+  [:p {:class '[font-serif dark:text-gray-200 "flex-4/3"]}])

--- a/lib/processor/src/girouette/processor.clj
+++ b/lib/processor/src/girouette/processor.clj
@@ -72,6 +72,13 @@
       (hook-fn (-> ast :val)))
     ast))
 
+(defn- symbol-hook [hook-fn]
+  (fn [env ast opts]
+    (when (and (= (:op ast) :const)
+               (= (:tag ast) 'cljs.core/Symbol))
+      (hook-fn (-> ast :val)))
+    ast))
+
 ;(ana-api/analyze nil "hi")
 ;(ana-api/analyze nil :hi)
 
@@ -93,6 +100,10 @@
                                                  (let [names (->> (name kw)
                                                                   (re-seq #"\.[^\.#]+")
                                                                   (map (fn [s] (subs s 1))))]
+                                                   (swap! css-classes into names))))
+                                 (symbol-hook (fn [sym]
+                                                 (let [names (->> (name sym)
+                                                                  (re-seq #"[\S]+"))]
                                                    (swap! css-classes into names))))]
                  :annotated [(invoke-hook (:css-symb @config)
                                           (fn [form]


### PR DESCRIPTION
I currently use tailwind as a js library and it has no support for using strings.
Because of this, I decided to add support for this functionality so I can use girouette as a drop-in replacement for tailwind in my clojurescript projects.
```clojure
;; You can now write
[:tag {:class '[class-name another-class-name]} "content"]
;; As opposed to just
[:tag {:class '["class-name another-class-name"]} "content"]
;; Or
[:tag.class-name.another-class-name "content"]
```