### PR TITLE
Remove enable-console-print! line

### DIFF
--- a/example/reagent-demo/src/acme/frontend/app.cljc
+++ b/example/reagent-demo/src/acme/frontend/app.cljc
@@ -2,8 +2,6 @@
   (:require [reagent.dom :as rdom]
             [girouette.core :refer [css]]))
 
-(enable-console-print!)
-
 (defn simple-example []
   [:main
 


### PR DESCRIPTION
As Shadow-cljs enables this option by default, we can remove this line.
https://github.com/thheller/shadow-cljs/blob/ba0a02aec050c6bc8db1932916009400f99d3cce/src/main/shadow/cljs/devtools/client/env.cljs#L117