### PR TITLE
Fixing first, last, odd, even pseudo-classes

### DIFF
--- a/lib/girouette/src/girouette/tw/common.cljc
+++ b/lib/girouette/src/girouette/tw/common.cljc
@@ -7,6 +7,11 @@
 ;; It literally means "look ahead to see 'nop', then see 'no-way'".
 (def matches-nothing "&'nop' 'no-way'")
 
+(def state-variants {"first" "first-child"
+                     "last"  "last-child"
+                     "odd"   "nth-child(odd)"
+                     "even"  "nth-child(even)"})
+
 (defn dot [class]
   (str "." (str/escape class {\. "\\."
                               \: "\\:"
@@ -93,7 +98,7 @@
 
 (defn inner-state-variants-transform [rule props]
   (reduce (fn [rule state-variant]
-            [(keyword (str "&:" state-variant)) rule])
+            [(keyword (str "&:" (get state-variants state-variant state-variant))) rule])
           rule
           (->> props :prefixes :state-variants reverse
                (remove #{"group-hover" "group-focus"

--- a/lib/girouette/test/girouette/tw/common_test.cljc
+++ b/lib/girouette/test/girouette/tw/common_test.cljc
@@ -125,6 +125,18 @@
     "focus:container"
     [".focus\\:container" [:&:focus {:width "100%"}]]
 
+    "first:container"
+    [".first\\:container" [:&:first-child {:width "100%"}]]
+
+    "last:container"
+    [".last\\:container" [:&:last-child {:width "100%"}]]
+
+    "odd:container"
+    [".odd\\:container" [(keyword "&:nth-child(odd)") {:width "100%"}]]
+
+    "even:container"
+    [".even\\:container" [(keyword "&:nth-child(even)") {:width "100%"}]]
+
     "sm:focus:container"
     #garden.types.CSSAtRule{:identifier :media
                             :value {:media-queries {:min-width "640px"}
@@ -133,4 +145,4 @@
     "sm:first:focus:container"
     #garden.types.CSSAtRule{:identifier :media
                             :value {:media-queries {:min-width "640px"}
-                                    :rules ([".sm\\:first\\:focus\\:container" [:&:first [:&:focus {:max-width "640px"}]]])}}))
+                                    :rules ([".sm\\:first\\:focus\\:container" [:&:first-child [:&:focus {:max-width "640px"}]]])}}))


### PR DESCRIPTION
`first`, `last`, `odd`, `even` state-variants should generate correct pseudo-classes:

```
"first:container" => "first\:container:first-child"
"last:container" => "last\:container:last-child"
"odd:container" => "odd\:container:nth-child(odd)"
"even:container" => "even\:container:nth-child(even)"
```