### PR TITLE
Fix setting opacity of background color

### DIFF
--- a/lib/girouette/src/girouette/tw/background.cljc
+++ b/lib/girouette/src/girouette/tw/background.cljc
@@ -35,8 +35,7 @@
                   (let [[r g b a] color]
                     (if (some? a)
                       {:background-color (color->css color)}
-                      {:--gi-bg-opacity 1
-                       :background-color (color->css [r g b "var(--gi-bg-opacity)"])})))))}
+                      {:background-color (color->css [r g b "var(--gi-bg-opacity, 1)"])})))))}
 
 
    {:id :background-opacity

--- a/lib/girouette/src/girouette/tw/background.cljc
+++ b/lib/girouette/src/girouette/tw/background.cljc
@@ -35,7 +35,7 @@
                   (let [[r g b a] color]
                     (if (some? a)
                       {:background-color (color->css color)}
-                      {:background-color (color->css [r g b "var(--gi-bg-opacity, 1)"])})))))}
+                      {:background-color (color->css [r g b "var(--gi-bg-opacity,1)"])})))))}
 
 
    {:id :background-opacity

--- a/lib/girouette/src/girouette/tw/border.cljc
+++ b/lib/girouette/src/girouette/tw/border.cljc
@@ -72,8 +72,7 @@
                   (let [[r g b a] color]
                     (if (some? a)
                       {:border-color (color->css color)}
-                      {:--gi-border-opacity 1
-                       :border-color (color->css [r g b "var(--gi-border-opacity)"])})))))}
+                      {:border-color (color->css [r g b "var(--gi-border-opacity,1)"])})))))}
 
 
    {:id :border-opacity
@@ -129,8 +128,7 @@
                   (let [[r g b a] color]
                     (if (some? a)
                       {:border-color (color->css color)}
-                      {:--gi-divide-opacity 1
-                       :border-color (color->css [r g b "var(--gi-divide-opacity)"])})))))}
+                      {:border-color (color->css [r g b "var(--gi-divide-opacity,1)"])})))))}
 
 
    {:id :divide-opacity

--- a/lib/girouette/test/girouette/tw/background_test.cljc
+++ b/lib/girouette/test/girouette/tw/background_test.cljc
@@ -10,8 +10,7 @@
     [".bg-transparent" {:background-color "transparent"}]
 
     "bg-green-300"
-    [".bg-green-300" {:--gi-bg-opacity 1
-                      :background-color "rgba(134,239,172,var(--gi-bg-opacity))"}]
+    [".bg-green-300" {:background-color "rgba(134,239,172,var(--gi-bg-opacity,1))"}]
 
     "bg-repeat-round"
     [".bg-repeat-round" {:background-repeat "round"}]

--- a/lib/girouette/test/girouette/tw/border_test.cljc
+++ b/lib/girouette/test/girouette/tw/border_test.cljc
@@ -46,8 +46,7 @@
     [".border-transparent" {:border-color "transparent"}]
 
     "border-green-300"
-    [".border-green-300" {:--gi-border-opacity 1
-                          :border-color        "rgba(134,239,172,var(--gi-border-opacity))"}]
+    [".border-green-300" {:border-color        "rgba(134,239,172,var(--gi-border-opacity,1))"}]
 
     ;; Border Opacity
     "border-opacity-25"
@@ -77,8 +76,7 @@
 
     "divide-gray-100"
     [#garden.selectors.CSSSelector{:selector ".divide-gray-100 > * + *"}
-     {:--gi-divide-opacity 1
-      :border-color        "rgba(244,244,245,var(--gi-divide-opacity))"}]
+     {:border-color        "rgba(244,244,245,var(--gi-divide-opacity,1))"}]
 
     ;; Divide Opacity
     "divide-opacity-70"


### PR DESCRIPTION
If setting the --gi-bg-opacity with the same class as the one that is setting the background color, then a .bg-opacity-N won't override the variable. Instead, we can use the var-with-fallback for the background-color class.