### PR TITLE
Fix line height for text sizes starting at 5xl and above.

### DIFF
--- a/lib/girouette/src/girouette/tw/typography.cljc
+++ b/lib/girouette/src/girouette/tw/typography.cljc
@@ -42,22 +42,25 @@
     font-size = <'text-'> ('xs' | 'sm' | 'base' | 'lg' | 'xl' | '2xl' | '3xl' |
                            '4xl' | '5xl' | '6xl' | '7xl' | '8xl' | '9xl')
     "
-    :garden (fn [{[font-size] :component-data}]
-              (let [[size height] ({"xs"   [0.75  1]
-                                    "sm"   [0.875 1.25]
-                                    "base" [1     1.5]
-                                    "lg"   [1.125 1.75]
-                                    "xl"   [1.25  1.75]
-                                    "2xl"  [1.5   2]
-                                    "3xl"  [1.875 2.25]
-                                    "4xl"  [2.25  2.5]
-                                    "5xl"  [3     1]
-                                    "6xl"  [3.75  1]
-                                    "7xl"  [4.5   1]
-                                    "8xl"  [6     1]
-                                    "9xl"  [8     1]} font-size)]
-                   {:font-size (str size "rem")
-                    :line-height (str height "rem")}))}
+    :garden (let [no-height-unit? #{"5xl" "6xl" "7xl" "8xl" "9xl"}]
+              (fn [{[font-size] :component-data}]
+               (let [[size height] ({"xs"   [0.75  1]
+                                     "sm"   [0.875 1.25]
+                                     "base" [1     1.5]
+                                     "lg"   [1.125 1.75]
+                                     "xl"   [1.25  1.75]
+                                     "2xl"  [1.5   2]
+                                     "3xl"  [1.875 2.25]
+                                     "4xl"  [2.25  2.5]
+                                     "5xl"  [3     1]
+                                     "6xl"  [3.75  1]
+                                     "7xl"  [4.5   1]
+                                     "8xl"  [6     1]
+                                     "9xl"  [8     1]} font-size)]
+                    {:font-size (str size "rem")
+                     :line-height (str height (if (no-height-unit? font-size)
+                                                ""
+                                                "rem"))})))}
 
 
    ;; This is an extra, not from Tailwind.

--- a/lib/girouette/test/girouette/tw/typography_test.cljc
+++ b/lib/girouette/test/girouette/tw/typography_test.cljc
@@ -14,6 +14,10 @@
     [".text-sm" {:font-size (str 0.875 "rem")
                  :line-height (str 1.25 "rem")}]
 
+    "text-5xl"
+    [".text-5xl" {:font-size (str 3 "rem")
+                  :line-height (str 1)}]
+
     "font-size-10"
     [".font-size-10" {:font-size "2.5rem"}]
 


### PR DESCRIPTION
When using predefined text size with classes like `text-sm`, etc...  the generated css sets not only `font-size` but also `line-height`. This is what tailwind also does. However starting at 5xl and up, tailwind sets `line-height` to `1` where girouette sets it to `1rem`. This produces lines smaller than the characters in them, graphically things start to render on top of each other.

For reference here is [the link](https://tailwindcss.com/docs/font-size) to the relevant classes in tailwind's doc.

This request proposes to fix this issue by conditioning the addition of the `rem` unit based on the font-size.

Cheers,