### PR TITLE
Fix child selector issue in `ornament`

### DIFF
--- a/lib/girouette/src/girouette/tw/border.cljc
+++ b/lib/girouette/src/girouette/tw/border.cljc
@@ -1,6 +1,6 @@
 (ns ^:no-doc girouette.tw.border
   (:require [garden.selectors :as gs]
-            [girouette.tw.common :refer [value-unit->css div-100]]
+            [girouette.tw.common :refer [value-unit->css div-100 between-children-selector]]
             [girouette.tw.color :refer [color->css]]))
 
 (def components
@@ -104,9 +104,8 @@
                 (let [width (if (nil? value)
                               "1px"
                               (value-unit->css value {:zero-unit nil
-                                                      :number {:unit "px"}}))
-                      selector (gs/> gs/& (gs/+ :* :*))]
-                  [selector
+                                                      :number {:unit "px"}}))]
+                  [between-children-selector
                    (case axis
                      "x" {:border-right-width (str "calc(" width " * var(--gi-divide-x-reverse))")
                           :border-left-width  (str "calc(" width " * calc(1 - var(--gi-divide-x-reverse)))")}
@@ -120,9 +119,8 @@
     "
     :garden (fn [{[color] :component-data
                   read-color :read-color}]
-              (let [color (read-color color)
-                    selector (gs/> gs/& (gs/+ :* :*))]
-                [selector
+              (let [color (read-color color)]
+                [between-children-selector
                  (if (string? color)
                    {:border-color color}
                    (let [[r g b a] color]
@@ -146,7 +144,7 @@
     divide-style = <'divide-'> ('solid' | 'dashed' | 'dotted' | 'double' | 'none')
     "
     :garden (fn [{[border-style] :component-data}]
-              [(gs/> gs/& (gs/+ :* :*))
+              [between-children-selector
                {:border-style border-style}])}
 
 

--- a/lib/girouette/src/girouette/tw/border.cljc
+++ b/lib/girouette/src/girouette/tw/border.cljc
@@ -1,6 +1,6 @@
 (ns ^:no-doc girouette.tw.border
   (:require [garden.selectors :as gs]
-            [girouette.tw.common :refer [value-unit->css dot default-pipeline div-100]]
+            [girouette.tw.common :refer [value-unit->css div-100]]
             [girouette.tw.color :refer [color->css]]))
 
 (def components
@@ -98,40 +98,38 @@
     divide-width = <'divide-'> axis (<'-'> divide-width-value)?
     divide-width-value = number | length | length-unit
     "
-    :pipeline (assoc default-pipeline
-                :class-name [(fn [rule props]
-                               [(gs/> (dot (:class-name props)) (gs/+ :* :*)) rule])])
     :garden (fn [{:keys [component-data]}]
               (let [{axis  :axis
                      value :divide-width-value} (into {} component-data)]
                 (let [width (if (nil? value)
                               "1px"
                               (value-unit->css value {:zero-unit nil
-                                                      :number {:unit "px"}}))]
-                  (case axis
-                    "x" {:border-right-width (str "calc(" width " * var(--gi-divide-x-reverse))")
-                         :border-left-width  (str "calc(" width " * calc(1 - var(--gi-divide-x-reverse)))")}
-                    "y" {:border-top-width    (str "calc(" width " * var(--gi-divide-y-reverse))")
-                         :border-bottom-width (str "calc(" width " * calc(1 - var(--gi-divide-y-reverse)))")}))))}
+                                                      :number {:unit "px"}}))
+                      selector (gs/> gs/& (gs/+ :* :*))]
+                  [selector
+                   (case axis
+                     "x" {:border-right-width (str "calc(" width " * var(--gi-divide-x-reverse))")
+                          :border-left-width  (str "calc(" width " * calc(1 - var(--gi-divide-x-reverse)))")}
+                     "y" {:border-top-width    (str "calc(" width " * var(--gi-divide-y-reverse))")
+                          :border-bottom-width (str "calc(" width " * calc(1 - var(--gi-divide-y-reverse)))")})])))}
 
 
    {:id :divide-color
     :rules "
     divide-color = <'divide-'> color
     "
-    :pipeline (assoc default-pipeline
-                :class-name [(fn [rule props]
-                               [(gs/> (dot (:class-name props)) (gs/+ :* :*)) rule])])
     :garden (fn [{[color] :component-data
                   read-color :read-color}]
-              (let [color (read-color color)]
-                (if (string? color)
-                  {:border-color color}
-                  (let [[r g b a] color]
-                    (if (some? a)
-                      {:border-color (color->css color)}
-                      {:--gi-divide-opacity 1
-                       :border-color (color->css [r g b "var(--gi-divide-opacity)"])})))))
+              (let [color (read-color color)
+                    selector (gs/> gs/& (gs/+ :* :*))]
+                [selector
+                 (if (string? color)
+                   {:border-color color}
+                   (let [[r g b a] color]
+                     (if (some? a)
+                       {:border-color (color->css color)}
+                       {:--gi-divide-opacity 1
+                        :border-color (color->css [r g b "var(--gi-divide-opacity)"])})))]))
     :before-rules #{:divide-opacity}}
 
 
@@ -147,11 +145,9 @@
     :rules "
     divide-style = <'divide-'> ('solid' | 'dashed' | 'dotted' | 'double' | 'none')
     "
-    :pipeline (assoc default-pipeline
-                :class-name [(fn [rule props]
-                               [(gs/> (dot (:class-name props)) (gs/+ :* :*)) rule])])
     :garden (fn [{[border-style] :component-data}]
-              {:border-style border-style})}
+              [(gs/> gs/& (gs/+ :* :*))
+               {:border-style border-style}])}
 
 
    {:id :ring-width

--- a/lib/girouette/src/girouette/tw/common.cljc
+++ b/lib/girouette/src/girouette/tw/common.cljc
@@ -1,6 +1,7 @@
 (ns ^:no-doc girouette.tw.common
   (:require [clojure.string :as str]
             [clojure.edn :as edn]
+            [garden.selectors]
             [garden.stylesheet :as gs]))
 
 ;; This Instaparse grammar matches nothing.
@@ -111,6 +112,15 @@
 
 (defn class-name-transform [rule props]
   [(dot (:class-name props)) rule])
+
+
+(def between-children-selector
+  "Selects every direct child of an element except the last.
+   Commonly used to visually style 'between' a list of elements.
+
+  For example:
+  .space-y-2 uses this selector to add space between elements"
+  #garden.selectors.CSSSelector{:selector "&>*+*"})
 
 
 (defn outer-state-variants-transform [rule props]

--- a/lib/girouette/src/girouette/tw/spacing.cljc
+++ b/lib/girouette/src/girouette/tw/spacing.cljc
@@ -1,6 +1,6 @@
 (ns ^:no-doc girouette.tw.spacing
   (:require [garden.selectors :as gs]
-            [girouette.tw.common :refer [value-unit->css dot default-pipeline div-4]]))
+            [girouette.tw.common :refer [value-unit->css div-4]]))
 
 
 (def components
@@ -63,9 +63,6 @@
     space-between-value = number | length | length-unit
     space-between-reverse = 'reverse'
     "
-    :pipeline (assoc default-pipeline
-                :class-name [(fn [rule props]
-                               [(gs/> (dot (:class-name props)) (gs/+ :* :*)) rule])])
     :garden (fn [{component-data :component-data}]
               (let [{:keys [signus axis space-between-value space-between-reverse]} (into {} component-data)
                     direction ({["x" false] "left"
@@ -75,5 +72,6 @@
                     value-css (value-unit->css space-between-value {:signus signus
                                                                     :zero-unit nil
                                                                     :number {:unit "rem"
-                                                                             :value-fn div-4}})]
-                {(keyword (str "margin-" direction)) value-css}))}])
+                                                                             :value-fn div-4}})
+                    selector (gs/> gs/& (gs/+ :* :*))]
+                [selector {(keyword (str "margin-" direction)) value-css}]))}])

--- a/lib/girouette/src/girouette/tw/spacing.cljc
+++ b/lib/girouette/src/girouette/tw/spacing.cljc
@@ -1,6 +1,6 @@
 (ns ^:no-doc girouette.tw.spacing
   (:require [garden.selectors :as gs]
-            [girouette.tw.common :refer [value-unit->css div-4]]))
+            [girouette.tw.common :refer [value-unit->css div-4 between-children-selector]]))
 
 
 (def components
@@ -72,6 +72,5 @@
                     value-css (value-unit->css space-between-value {:signus signus
                                                                     :zero-unit nil
                                                                     :number {:unit "rem"
-                                                                             :value-fn div-4}})
-                    selector (gs/> gs/& (gs/+ :* :*))]
-                [selector {(keyword (str "margin-" direction)) value-css}]))}])
+                                                                             :value-fn div-4}})]
+                [between-children-selector {(keyword (str "margin-" direction)) value-css}]))}])

--- a/lib/girouette/test/girouette/tw/border_test.cljc
+++ b/lib/girouette/test/girouette/tw/border_test.cljc
@@ -59,24 +59,24 @@
 
     ;; Divide Width
     "divide-x"
-    [".divide-x" [#garden.selectors.CSSSelector{:selector "& > * + *"}
+    [".divide-x" [#garden.selectors.CSSSelector{:selector "&>*+*"}
      {;;:--gi-divide-x-reverse 0 ;; Not implemented
       :border-right-width "calc(1px * var(--gi-divide-x-reverse))"
       :border-left-width  "calc(1px * calc(1 - var(--gi-divide-x-reverse)))"}]]
 
     "divide-y-2"
-    [".divide-y-2" [#garden.selectors.CSSSelector{:selector "& > * + *"}
+    [".divide-y-2" [#garden.selectors.CSSSelector{:selector "&>*+*"}
      {;;:--gi-divide-x-reverse 0 ;; Not implemented
       :border-top-width "calc(2px * var(--gi-divide-y-reverse))"
       :border-bottom-width  "calc(2px * calc(1 - var(--gi-divide-y-reverse)))"}]]
 
     ;; Divide Color
     "divide-current"
-    [".divide-current" [#garden.selectors.CSSSelector{:selector "& > * + *"}
+    [".divide-current" [#garden.selectors.CSSSelector{:selector "&>*+*"}
      {:border-color "currentColor"}]]
 
     "divide-gray-100"
-    [".divide-gray-100" [#garden.selectors.CSSSelector{:selector "& > * + *"}
+    [".divide-gray-100" [#garden.selectors.CSSSelector{:selector "&>*+*"}
      {:--gi-divide-opacity 1
       :border-color        "rgba(244,244,245,var(--gi-divide-opacity))"}]]
 
@@ -86,7 +86,7 @@
 
     ;; Divide Style
     "divide-double"
-    [".divide-double" [#garden.selectors.CSSSelector{:selector "& > * + *"}
+    [".divide-double" [#garden.selectors.CSSSelector{:selector "&>*+*"}
      {:border-style "double"}]]
 
     ;; Ring Width

--- a/lib/girouette/test/girouette/tw/border_test.cljc
+++ b/lib/girouette/test/girouette/tw/border_test.cljc
@@ -59,26 +59,26 @@
 
     ;; Divide Width
     "divide-x"
-    [#garden.selectors.CSSSelector{:selector ".divide-x > * + *"}
+    [".divide-x" [#garden.selectors.CSSSelector{:selector "& > * + *"}
      {;;:--gi-divide-x-reverse 0 ;; Not implemented
       :border-right-width "calc(1px * var(--gi-divide-x-reverse))"
-      :border-left-width  "calc(1px * calc(1 - var(--gi-divide-x-reverse)))"}]
+      :border-left-width  "calc(1px * calc(1 - var(--gi-divide-x-reverse)))"}]]
 
     "divide-y-2"
-    [#garden.selectors.CSSSelector{:selector ".divide-y-2 > * + *"}
+    [".divide-y-2" [#garden.selectors.CSSSelector{:selector "& > * + *"}
      {;;:--gi-divide-x-reverse 0 ;; Not implemented
       :border-top-width "calc(2px * var(--gi-divide-y-reverse))"
-      :border-bottom-width  "calc(2px * calc(1 - var(--gi-divide-y-reverse)))"}]
+      :border-bottom-width  "calc(2px * calc(1 - var(--gi-divide-y-reverse)))"}]]
 
     ;; Divide Color
     "divide-current"
-    [#garden.selectors.CSSSelector{:selector ".divide-current > * + *"}
-     {:border-color "currentColor"}]
+    [".divide-current" [#garden.selectors.CSSSelector{:selector "& > * + *"}
+     {:border-color "currentColor"}]]
 
     "divide-gray-100"
-    [#garden.selectors.CSSSelector{:selector ".divide-gray-100 > * + *"}
+    [".divide-gray-100" [#garden.selectors.CSSSelector{:selector "& > * + *"}
      {:--gi-divide-opacity 1
-      :border-color        "rgba(244,244,245,var(--gi-divide-opacity))"}]
+      :border-color        "rgba(244,244,245,var(--gi-divide-opacity))"}]]
 
     ;; Divide Opacity
     "divide-opacity-70"
@@ -86,8 +86,8 @@
 
     ;; Divide Style
     "divide-double"
-    [#garden.selectors.CSSSelector{:selector ".divide-double > * + *"}
-     {:border-style "double"}]
+    [".divide-double" [#garden.selectors.CSSSelector{:selector "& > * + *"}
+     {:border-style "double"}]]
 
     ;; Ring Width
     ;; TODO: Test for `*	box-shadow: 0 0 #0000;`

--- a/lib/girouette/test/girouette/tw/spacing_test.cljc
+++ b/lib/girouette/test/girouette/tw/spacing_test.cljc
@@ -50,13 +50,13 @@
                :margin-right "-0.5rem"}]
 
     "space-x-2"
-    [#garden.selectors.CSSSelector{:selector ".space-x-2 > * + *"} {:margin-left "0.5rem"}]
+    [".space-x-2" [#garden.selectors.CSSSelector{:selector "& > * + *"} {:margin-left "0.5rem"}]]
 
     "space-y-2"
-    [#garden.selectors.CSSSelector{:selector ".space-y-2 > * + *"} {:margin-top "0.5rem"}]
+    [".space-y-2" [#garden.selectors.CSSSelector{:selector "& > * + *"} {:margin-top "0.5rem"}]]
 
     "space-x-2-reverse"
-    [#garden.selectors.CSSSelector{:selector ".space-x-2-reverse > * + *"} {:margin-right "0.5rem"}]
+    [".space-x-2-reverse" [#garden.selectors.CSSSelector{:selector "& > * + *"} {:margin-right "0.5rem"}]]
 
     "space-y-2-reverse"
-    [#garden.selectors.CSSSelector{:selector ".space-y-2-reverse > * + *"} {:margin-bottom "0.5rem"}]))
+    [".space-y-2-reverse" [#garden.selectors.CSSSelector{:selector "& > * + *"} {:margin-bottom "0.5rem"}]]))

--- a/lib/girouette/test/girouette/tw/spacing_test.cljc
+++ b/lib/girouette/test/girouette/tw/spacing_test.cljc
@@ -50,13 +50,13 @@
                :margin-right "-0.5rem"}]
 
     "space-x-2"
-    [".space-x-2" [#garden.selectors.CSSSelector{:selector "& > * + *"} {:margin-left "0.5rem"}]]
+    [".space-x-2" [#garden.selectors.CSSSelector{:selector "&>*+*"} {:margin-left "0.5rem"}]]
 
     "space-y-2"
-    [".space-y-2" [#garden.selectors.CSSSelector{:selector "& > * + *"} {:margin-top "0.5rem"}]]
+    [".space-y-2" [#garden.selectors.CSSSelector{:selector "&>*+*"} {:margin-top "0.5rem"}]]
 
     "space-x-2-reverse"
-    [".space-x-2-reverse" [#garden.selectors.CSSSelector{:selector "& > * + *"} {:margin-right "0.5rem"}]]
+    [".space-x-2-reverse" [#garden.selectors.CSSSelector{:selector "&>*+*"} {:margin-right "0.5rem"}]]
 
     "space-y-2-reverse"
-    [".space-y-2-reverse" [#garden.selectors.CSSSelector{:selector "& > * + *"} {:margin-bottom "0.5rem"}]]))
+    [".space-y-2-reverse" [#garden.selectors.CSSSelector{:selector "&>*+*"} {:margin-bottom "0.5rem"}]]))


### PR DESCRIPTION
`lambdaisland/ornament` ignores the class names generated by `girouette`
and substitutes its own. This causes issues when `girouette` returns not
only a class name but also some additional selector. In this case, the
family of tailwind utilities like `space-x-2` was causing issues because
it uses a common CSS selector pattern of: `.space-x-2 > * + *`.

To fix the issue, I've modified the implementation of several tw
utilities to have one additional layer of nesting in the garden output.

See the changes to the unit tests for an example.

See this discussion over on the `ornament` repo: https://github.com/lambdaisland/ornament/issues/5