### PR TITLE
Fix `.invisible` class setting an invalid attribute for visibility

### DIFF
--- a/lib/girouette/src/girouette/tw/layout.cljc
+++ b/lib/girouette/src/girouette/tw/layout.cljc
@@ -134,7 +134,9 @@
     visibility = 'visible' | 'invisible'
     "
     :garden (fn [{[visibility] :component-data}]
-              {:visibility visibility})}
+              {:visibility (if (= visibility "invisible")
+                             "hidden"
+                             visibility)})}
 
 
    {:id :z-index

--- a/lib/girouette/test/girouette/tw/layout_test.cljc
+++ b/lib/girouette/test/girouette/tw/layout_test.cljc
@@ -50,7 +50,7 @@
     [".overscroll-none" {:overscroll "none"}]
 
     "invisible"
-    [".invisible" {:visibility "invisible"}]
+    [".invisible" {:visibility "hidden"}]
 
     "-inset-3/8"
     [".-inset-3\\/8"


### PR DESCRIPTION
The class `.invisible` should set the `visibility` attribute to `hidden`, not `invisible`. See [MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/visibility) or [what tailwind does](https://tailwindcss.com/docs/visibility).