### PR TITLE
Don't pass literal characters to string-hook

### DIFF
--- a/lib/processor/src/girouette/processor.clj
+++ b/lib/processor/src/girouette/processor.clj
@@ -70,7 +70,8 @@
 (defn- string-hook [hook-fn]
   (fn [env ast opts]
     (when (and (= (:op ast) :const)
-               (= (:tag ast) 'string))
+               (= (:tag ast) 'string)
+               (not (char? (:val ast))))
       (hook-fn (-> ast :val)))
     ast))
 


### PR DESCRIPTION
The cljs.analyzer.api function apparently identifiers literal
characters (e.g. `\a`) as `string` nodes. These leads to an error when
the string hook function is called with a character, instead of a
string, which results in parsing failing if a file contains any
literal characters.