### PR TITLE
Catch up to Tailwind 3.0.18

### DIFF
--- a/lib/girouette/src/girouette/tw/background.cljc
+++ b/lib/girouette/src/girouette/tw/background.cljc
@@ -39,6 +39,12 @@
                        :background-color (color->css [r g b "var(--gi-bg-opacity)"])})))))
     :before-rules #{:background-opacity}}
 
+   {:id :background-origin
+    :rules "
+    background-origin = <'bg-origin-'> ( 'border' | 'padding' | 'content' )
+    "
+    :garden (fn [{[value] :component-data}]
+              {:background-origin (str value "-box")})}
 
    {:id :background-opacity
     :rules "

--- a/lib/girouette/src/girouette/tw/border.cljc
+++ b/lib/girouette/src/girouette/tw/border.cljc
@@ -108,7 +108,7 @@
 
    {:id :border-style
     :rules "
-    border-style = <'border-'> ('solid' | 'dashed' | 'dotted' | 'double' | 'none')
+    border-style = <'border-'> ('solid' | 'dashed' | 'dotted' | 'double' | 'none' | 'hidden')
     "
     :garden (fn [{[border-style] :component-data}]
               {:border-style border-style})}

--- a/lib/girouette/src/girouette/tw/border.cljc
+++ b/lib/girouette/src/girouette/tw/border.cljc
@@ -75,6 +75,28 @@
                        :border-color (color->css [r g b "var(--gi-border-opacity)"])})))))
     :before-rules #{:border-opacity}}
 
+   {:id :border-side-color
+    :rules "
+    border-side-color = <'border-'> border-side-color-side <'-'> color
+    border-side-color-side = 't' | 'b' | 'l' | 'r'
+    "
+    :garden (fn [{:keys [component-data read-color]}]
+              (let [{:keys [border-side-color-side color]} (into {} component-data)
+                    color (read-color [:color color])
+                    border-key (keyword (str "border-"
+                                             (case border-side-color-side
+                                               "t" "top"
+                                               "b" "bottom"
+                                               "l" "left"
+                                               "r" "right")
+                                             "-color"))
+                    [r g b a] color]
+                (if (some? a)
+                  {border-key (color->css color)}
+                  {:--gi-border-opacity 1
+                   border-key (color->css [r g b "var(--gi-border-opacity)"])})))
+    :before-rules #{:border-opacity}}
+
 
    {:id :border-opacity
     :rules "

--- a/lib/girouette/src/girouette/tw/border.cljc
+++ b/lib/girouette/src/girouette/tw/border.cljc
@@ -201,6 +201,17 @@
                {:border-style border-style}])}
 
 
+   {:id :outline
+    :rules "
+    outline = <'outline-'> ('none' | 'white' | 'black')
+    "
+    :garden (fn [{[type] :component-data}]
+              {:outline ({"none" "2px solid transparent"
+                          "white" "2px dotted white"
+                          "black" "2px dotted black"} type)
+               :outline-offset "2px"})}
+
+
    {:id :ring-width
     :rules "
     ring-width = <'ring'> (<'-'> ('inset' | number | length | length-unit))?

--- a/lib/girouette/src/girouette/tw/border.cljc
+++ b/lib/girouette/src/girouette/tw/border.cljc
@@ -201,16 +201,48 @@
                {:border-style border-style}])}
 
 
-   {:id :outline
+   {:id :outline-style
     :rules "
-    outline = <'outline-'> ('none' | 'white' | 'black')
+    outline-style = <'outline'> ( <'-'> outline-style-value )?
+    <outline-style-value> = 'none' | 'dashed' | 'dotted' | 'double' | 'hidden'
     "
     :garden (fn [{[type] :component-data}]
-              {:outline ({"none" "2px solid transparent"
-                          "white" "2px dotted white"
-                          "black" "2px dotted black"} type)
-               :outline-offset "2px"})}
+              (cond
+                (nil? type)
+                {:outline-style "solid"}
 
+                (= type "none")
+                {:outline "2px solid transparent"
+                 :outline-offset "2px"}
+
+                :else
+                {:outline-style type}))}
+
+
+   {:id :outline-color
+    :rules "
+    outline-color = <'outline-'> color
+    "
+    :garden (fn [{[value] :component-data read-color :read-color}]
+              {:outline-color (color->css (read-color value))})}
+
+
+   {:id :outline-offset
+    :rules "
+    outline-offset = <'outline-offset-'> ( number | length )
+    "
+    :garden (fn [{[value] :component-data}]
+              {:outline-offset (value-unit->css value {:zero-unit "px"
+                                                       :number {:unit "px"}})})}
+
+
+   {:id :outline-width
+    :rules "
+    outline-width = <'outline-'> ( number | length )
+    "
+    :garden (fn [{[value] :component-data}]
+              {:outline-width (value-unit->css value {:zero-unit "px"
+                                                      :number {:unit "px"}})})}
 
    {:id :ring-width
     :rules "

--- a/lib/girouette/src/girouette/tw/box_alignment.cljc
+++ b/lib/girouette/src/girouette/tw/box_alignment.cljc
@@ -57,10 +57,11 @@
 
    {:id :align-self
     :rules "
-    align-self = <'self-'> ('auto' | 'start' | 'end' | 'center' | 'stretch')
+    align-self = <'self-'> ('auto' | 'start' | 'end' | 'center' | 'stretch' | 'baseline' )
     "
     :garden (fn [{[param] :component-data}]
               {:align-self ({"auto" "auto"
+                             "baseline" "baseline"
                              "start" "flex-start"
                              "end" "flex-end"
                              "center" "center"

--- a/lib/girouette/src/girouette/tw/color.cljc
+++ b/lib/girouette/src/girouette/tw/color.cljc
@@ -98,6 +98,17 @@
    "lightBlue-800" "075985"
    "lightBlue-900" "0c4a6e"
 
+   "sky-50" "f0f9ff"
+   "sky-100" "e0f2fe"
+   "sky-200" "bae6fd"
+   "sky-300" "7dd3fc"
+   "sky-400" "38bdf8"
+   "sky-500" "0ea5e9"
+   "sky-600" "0284c7"
+   "sky-700" "0369a1"
+   "sky-800" "075985"
+   "sky-900" "0c4a6e"
+
    "cyan-50" "ecfeff"
    "cyan-100" "cffafe"
    "cyan-200" "a5f3fc"

--- a/lib/girouette/src/girouette/tw/color.cljc
+++ b/lib/girouette/src/girouette/tw/color.cljc
@@ -287,7 +287,7 @@
   <color-opacity> = number
 
   special-color = 'transparent' | 'current'
-  predefined-color-opacity = predefined-color (<'-'> color-opacity)?
+  predefined-color-opacity = predefined-color (<'-' | '/'> color-opacity)?
 
   <predefined-color> = " color-names "
 ")))

--- a/lib/girouette/src/girouette/tw/common.cljc
+++ b/lib/girouette/src/girouette/tw/common.cljc
@@ -14,9 +14,9 @@
     "odd"   "nth-child(odd)"
     "even"  "nth-child(even)"} state-variant state-variant))
 
-(def outer-state-variants
-  #{"group-hover" "group-focus"
-    "group-disabled" "group-active"})
+(defn outer-state-variants
+  [variant]
+  (and (coll? variant) (= :group-state-variant (first variant))))
 
 (defn dot [class]
   (str "." (str/escape class {\. "\\."
@@ -126,11 +126,8 @@
 
 (defn outer-state-variants-transform [rule props]
   (reduce (fn [rule state-variant]
-            (case state-variant
-              "group-hover" [".group:hover" rule]
-              "group-focus" [".group:focus" rule]
-              "group-disabled" [".group:disabled" rule]
-              "group-active" [".group:active" rule]))
+            [(str ".group:" (state-variant->str (second state-variant)))
+             rule])
           rule
           (->> props :prefixes :state-variants reverse
                (filter outer-state-variants))))
@@ -168,14 +165,15 @@
   media-query-color-scheme = 'light' | 'dark'
   media-query-reduced-motion = 'motion-safe' | 'motion-reduce'
 
-  state-variant = 'hover' | 'focus' | 'disabled' | 'active' |
-                  'group-hover' | 'group-focus' | 'group-disabled' | 'group-active' |
+  <state-variant-value> = 'hover' | 'focus' | 'disabled' | 'active' |
                   'focus-within' | 'focus-visible' |
                   'any-link' | 'link' | 'visited' | 'target' |
                   'blank' | 'required' | 'optional' | 'valid' | 'invalid' | 'placeholder-shown' | 'checked' |
                   'read-only' | 'read-write' |
                   'first' | 'last' | 'odd' | 'even' | 'first-of-type' | 'last-of-type' |
                   'root' | 'empty'
+  group-state-variant = <'group-'> state-variant-value
+  state-variant = group-state-variant | state-variant-value
 
   signus = '-' | '+'
   direction = 't' | 'r' | 'b' | 'l'

--- a/lib/girouette/src/girouette/tw/common.cljc
+++ b/lib/girouette/src/girouette/tw/common.cljc
@@ -32,15 +32,9 @@
        (#{:group-state-variant :peer-state-variant} (first variant))))
 
 (defn dot [class]
-  (str "." (str/escape class {\. "\\."
-                              \: "\\:"
-                              \/ "\\/"
-                              \% "\\%"
-                              \& "\\&"
-                              \~ "\\~"
-                              \< "\\<"
-                              \> "\\>"
-                              \# "\\#"})))
+  (str "." (str/replace class #"[^-a-zA-Z0-9_]"
+                        ;; "\\\\$0" doesn't work in cljs, it seems?
+                        (fn [c] (str "\\" c)))))
 
 
 (def breakpoint->pixels

--- a/lib/girouette/src/girouette/tw/common.cljc
+++ b/lib/girouette/src/girouette/tw/common.cljc
@@ -246,4 +246,15 @@
 ")
 
 (def components
-  [])
+  [{:id :arbitrary-property
+    :rules "
+    arbitrary-property = <'['> #'[^\\] ]*' <']'>
+    "
+    :garden (fn [{[value] :component-data}]
+              (let [[prop val] (-> value
+                                   ;; negative-lookbehind isn't supported in javascript
+                                   (str/replace #"(^|[^\\])_" "$1 ")
+                                   (str/replace #"\\_" "_")
+                                   (str/split #":" 2))]
+                {(keyword prop) val}))}
+   ])

--- a/lib/girouette/src/girouette/tw/common.cljc
+++ b/lib/girouette/src/girouette/tw/common.cljc
@@ -169,10 +169,12 @@
         color-scheme (-> prefixes :media-query-color-scheme)
         reduced-motion (-> prefixes :media-query-reduced-motion {"motion-safe" "no-preference"
                                                                  "motion-reduce" "reduced"})
+        orientation (-> prefixes :media-query-orientation)
         media-query (cond-> {}
                       min-width (assoc :min-width min-width)
                       color-scheme (assoc :prefers-color-scheme color-scheme)
-                      reduced-motion (assoc :prefers-reduced-motion reduced-motion))]
+                      reduced-motion (assoc :prefers-reduced-motion reduced-motion)
+                      orientation (assoc :orientation orientation))]
     (if (seq media-query)
       (gs/at-media media-query rule)
       rule)))
@@ -190,10 +192,12 @@
 
   <media-query> = media-query-min-width |
                   media-query-color-scheme |
-                  media-query-reduced-motion
+                  media-query-reduced-motion |
+                  media-query-orientation
   media-query-min-width = 'sm' | 'md' | 'lg' | 'xl' | '2xl'
   media-query-color-scheme = 'light' | 'dark'
   media-query-reduced-motion = 'motion-safe' | 'motion-reduce'
+  media-query-orientation = 'landscape' | 'portrait'
 
   attribute-state-variant = 'open'
   <state-variant-value> = 'hover' | 'focus' | 'disabled' | 'active' |

--- a/lib/girouette/src/girouette/tw/common.cljc
+++ b/lib/girouette/src/girouette/tw/common.cljc
@@ -12,7 +12,8 @@
   ({"first" "first-child"
     "last"  "last-child"
     "odd"   "nth-child(odd)"
-    "even"  "nth-child(even)"} state-variant state-variant))
+    "even"  "nth-child(even)"
+    "file"  ":file-selector-button"} state-variant state-variant))
 
 (defn outer-state-variants
   [variant]
@@ -181,6 +182,7 @@
                   'blank' | 'required' | 'optional' | 'valid' | 'invalid' | 'placeholder-shown' | 'checked' |
                   'read-only' | 'read-write' |
                   'first' | 'last' | 'odd' | 'even' | 'first-of-type' | 'last-of-type' |
+                  'file' |
                   'root' | 'empty'
   group-state-variant = <'group-'> state-variant-value
   peer-state-variant = <'peer-'> state-variant-value

--- a/lib/girouette/src/girouette/tw/common.cljc
+++ b/lib/girouette/src/girouette/tw/common.cljc
@@ -15,12 +15,16 @@
          ({"first" "first-child"
            "last"  "last-child"
            "odd"   "nth-child(odd)"
-           "even"  "nth-child(even)"
-           "file"  ":file-selector-button"} state-variant state-variant))
+           "even"  "nth-child(even)"} state-variant state-variant))
 
     (and (coll? state-variant)
          (= :attribute-state-variant (first state-variant)))
     (str "[" (second state-variant) "]")))
+
+
+(defn target-variant->str [target-variant]
+  (str "::" ({"file" "file-selector-button"} target-variant target-variant)))
+
 
 (defn outer-state-variants
   [variant]
@@ -114,8 +118,15 @@
 
 
 (defn inner-state-variants-transform [rule props]
-  (reduce (fn [rule state-variant]
-            [(keyword (str "&" (state-variant->str state-variant))) rule])
+  (reduce (fn [rule [variant-type variant-value]]
+            [(keyword (str "&"
+                           (case variant-type
+                             :target-variant
+                             (target-variant->str variant-value)
+
+                             (:plain-state-variant :attribute-state-variant)
+                             (state-variant->str variant-value))))
+             rule])
           rule
           (->> props :prefixes :state-variants reverse
                (remove outer-state-variants))))
@@ -191,12 +202,13 @@
                   'blank' | 'required' | 'optional' | 'valid' | 'invalid' | 'placeholder-shown' | 'checked' |
                   'read-only' | 'read-write' |
                   'first' | 'last' | 'odd' | 'even' | 'first-of-type' | 'last-of-type' |
-                  'file' |
                   'root' | 'empty' |
                   attribute-state-variant
   group-state-variant = <'group-'> state-variant-value
   peer-state-variant = <'peer-'> state-variant-value
-  state-variant = group-state-variant | peer-state-variant | state-variant-value
+  target-variant = 'file'
+  plain-state-variant = state-variant-value
+  state-variant = group-state-variant | peer-state-variant | target-variant | plain-state-variant
 
   signus = '-' | '+'
   direction = 't' | 'r' | 'b' | 'l'

--- a/lib/girouette/src/girouette/tw/common.cljc
+++ b/lib/girouette/src/girouette/tw/common.cljc
@@ -87,6 +87,7 @@
      :full "full"
      :min-content "min-content"
      :max-content "max-content"
+     :fit-content "fit-content"
      (let [[data-type arg1 arg2] data
            [value unit] (case data-type
                           :integer [(read-number arg1) nil]
@@ -208,6 +209,7 @@
   screen-100vh = 'screen'
   min-content = 'min'
   max-content = 'max'
+  fit-content = 'fit'
   auto = 'auto'
   none = 'none'
   full = 'full'

--- a/lib/girouette/src/girouette/tw/common.cljc
+++ b/lib/girouette/src/girouette/tw/common.cljc
@@ -206,7 +206,7 @@
                   attribute-state-variant
   group-state-variant = <'group-'> state-variant-value
   peer-state-variant = <'peer-'> state-variant-value
-  target-variant = 'file'
+  target-variant = 'file' | 'before' | 'after' | 'placeholder'
   plain-state-variant = state-variant-value
   state-variant = group-state-variant | peer-state-variant | target-variant | plain-state-variant
 

--- a/lib/girouette/src/girouette/tw/core.cljc
+++ b/lib/girouette/src/girouette/tw/core.cljc
@@ -31,12 +31,14 @@
         {[media-query-min-width] :media-query-min-width
          [media-query-color-scheme] :media-query-color-scheme
          [media-query-reduced-motion] :media-query-reduced-motion
+         [media-query-orientation] :media-query-orientation
          state-variants :state-variant} (util/group-by first second prefixes)]
     (assoc predef-props
       :class-name class-name
       :prefixes {:media-query-min-width media-query-min-width
                  :media-query-color-scheme media-query-color-scheme
                  :media-query-reduced-motion media-query-reduced-motion
+                 :media-query-orientation media-query-orientation
                  :state-variants state-variants}
       :component-id component-id
       :component-data (vec component-data))))

--- a/lib/girouette/src/girouette/tw/effect.cljc
+++ b/lib/girouette/src/girouette/tw/effect.cljc
@@ -27,6 +27,31 @@
                                   "var(--gi-ring-shadow,0 0 #0000),"
                                   "var(--gi-shadow)")}))}
 
+   {:id :background-blend-mode
+    :rules "
+    <background-blend-mode-value> =
+                         'normal' | 'multiply' | 'screen' | 'overlay' |
+                         'darken' | 'lighten'  | 'color-dodge' |
+                         'color-burn' | 'hard-light' | 'soft-light' |
+                         'difference' | 'exclusion' | 'hue' | 'saturation' |
+                         'color' | 'luminosity'
+    background-blend-mode = <'bg-blend-'> background-blend-mode-value
+    "
+    :garden (fn [{[blend-mode] :component-data}]
+              {:background-blend-mode blend-mode})}
+
+   {:id :mix-blend-mode
+    :rules "
+    <mix-blend-mode-value> =
+                         'normal' | 'multiply' | 'screen' | 'overlay' |
+                         'darken' | 'lighten'  | 'color-dodge' |
+                         'color-burn' | 'hard-light' | 'soft-light' |
+                         'difference' | 'exclusion' | 'hue' | 'saturation' |
+                         'color' | 'luminosity'
+    mix-blend-mode = <'mix-blend-'> mix-blend-mode-value
+    "
+    :garden (fn [{[blend-mode] :component-data}]
+              {:mix-blend-mode blend-mode})}
 
    {:id :opacity
     :rules "

--- a/lib/girouette/src/girouette/tw/effect.cljc
+++ b/lib/girouette/src/girouette/tw/effect.cljc
@@ -2,7 +2,21 @@
   (:require [girouette.tw.common :refer [value-unit->css div-100]]))
 
 (def components
-  [{:id :box-shadow
+  [{:id :background-blend-mode
+    :rules "
+    <background-blend-mode-value> =
+                         'normal' | 'multiply' | 'screen' | 'overlay' |
+                         'darken' | 'lighten'  | 'color-dodge' |
+                         'color-burn' | 'hard-light' | 'soft-light' |
+                         'difference' | 'exclusion' | 'hue' | 'saturation' |
+                         'color' | 'luminosity'
+    background-blend-mode = <'bg-blend-'> background-blend-mode-value
+    "
+    :garden (fn [{[blend-mode] :component-data}]
+              {:background-blend-mode blend-mode})}
+
+
+   {:id :box-shadow
     :rules "
     box-shadow = <'shadow'> (<'-'> box-shadow-value)?
     box-shadow-value = 'sm' | 'md' | 'lg' | 'xl' | '2xl' | 'inner' | 'none'
@@ -27,18 +41,6 @@
                                   "var(--gi-ring-shadow,0 0 #0000),"
                                   "var(--gi-shadow)")}))}
 
-   {:id :background-blend-mode
-    :rules "
-    <background-blend-mode-value> =
-                         'normal' | 'multiply' | 'screen' | 'overlay' |
-                         'darken' | 'lighten'  | 'color-dodge' |
-                         'color-burn' | 'hard-light' | 'soft-light' |
-                         'difference' | 'exclusion' | 'hue' | 'saturation' |
-                         'color' | 'luminosity'
-    background-blend-mode = <'bg-blend-'> background-blend-mode-value
-    "
-    :garden (fn [{[blend-mode] :component-data}]
-              {:background-blend-mode blend-mode})}
 
    {:id :mix-blend-mode
     :rules "

--- a/lib/girouette/src/girouette/tw/effect.cljc
+++ b/lib/girouette/src/girouette/tw/effect.cljc
@@ -39,6 +39,17 @@
                 {:filter (str "blur(" blur ")")}))}
 
 
+   {:id :brightness
+    :rules "
+    brightness = <'brightness-'> number
+    "
+    :garden (fn [{[value] :component-data}]
+              {:filter (str "brightness(" (value-unit->css
+                                            value
+                                            {:value-fn div-100})
+                            ")")})}
+
+
    {:id :box-shadow
     :rules "
     box-shadow = <'shadow'> (<'-'> box-shadow-value)?

--- a/lib/girouette/src/girouette/tw/effect.cljc
+++ b/lib/girouette/src/girouette/tw/effect.cljc
@@ -1,5 +1,5 @@
 (ns ^:no-doc girouette.tw.effect
-  (:require [girouette.tw.common :refer [value-unit->css div-100]]))
+  (:require [girouette.tw.common :refer [value-unit->css div-100 mul-100]]))
 
 (def components
   [{:id :background-blend-mode
@@ -102,6 +102,22 @@
                         "2xl" "drop-shadow(0 25px 25px rgb(0 0 0 / 0.15))"
                         "none" "drop-shadow(0 0 #0000)")]
                 {:filter v}))}
+
+
+   {:id :grayscale
+    :rules "
+    grayscale = <'grayscale'> (<'-'> (number | fraction))?
+    "
+    :garden (fn [{[value] :component-data}]
+              (if (nil? value)
+                {:filter "grayscale(100%)"}
+                {:filter (str "grayscale("
+                              (value-unit->css value
+                                               {:number {:unit "%"
+                                                         :zero-unit nil}
+                                                :fraction {:unit "%"
+                                                           :value-fn mul-100}})
+                              ")")}))}
 
 
    {:id :mix-blend-mode

--- a/lib/girouette/src/girouette/tw/effect.cljc
+++ b/lib/girouette/src/girouette/tw/effect.cljc
@@ -140,6 +140,19 @@
                                      ")")
                :filter filter-rule})}
 
+   {:id :invert
+    :rules "
+    invert = <'invert'> (<'-'> number )?
+    "
+    :garden (fn [{[value] :component-data}]
+              {:--gi-invert (str "invert("
+                            (if (nil? value)
+                              "100%"
+                              (value-unit->css value {:number {:unit "%"}}))
+                            ")")
+               :filter filter-rule})}
+
+
    {:id :mix-blend-mode
     :rules "
     <mix-blend-mode-value> =

--- a/lib/girouette/src/girouette/tw/effect.cljc
+++ b/lib/girouette/src/girouette/tw/effect.cljc
@@ -1,6 +1,10 @@
 (ns ^:no-doc girouette.tw.effect
   (:require [girouette.tw.common :refer [value-unit->css div-100 mul-100]]))
 
+(def ^:private filter-rule
+  "var(--gi-blur, ) var(--gi-brightness, ) var(--gi-contrast, ) var(--gi-grayscale, ) var(--gi-hue-rotate, ) var(--gi-invert, ) var(--gi-saturate, ) var(--gi-sepia, ) var(--gi-drop-shadow, )"
+  )
+
 (def components
   [{:id :background-blend-mode
     :rules "
@@ -36,7 +40,8 @@
                                  "2xl" "40px"
                                  "3xl" "64px"
                                  "none" "0"} blur-value-fix))))]
-                {:filter (str "blur(" blur ")")}))}
+                {:--gi-blur (str "blur(" blur ")")
+                 :filter filter-rule}))}
 
 
    {:id :brightness
@@ -44,10 +49,11 @@
     brightness = <'brightness-'> number
     "
     :garden (fn [{[value] :component-data}]
-              {:filter (str "brightness(" (value-unit->css
-                                            value
-                                            {:value-fn div-100})
-                            ")")})}
+              {:--gi-brightness (str "brightness(" (value-unit->css
+                                                     value
+                                                     {:value-fn div-100})
+                                     ")")
+               :filter filter-rule})}
 
 
    {:id :box-shadow
@@ -81,10 +87,11 @@
     contrast = <'contrast-'> number
     "
     :garden (fn [{[value] :component-data}]
-              {:filter (str "contrast(" (value-unit->css
-                                          value
-                                          {:value-fn div-100})
-                            ")")})}
+              {:--gi-contrast (str "contrast(" (value-unit->css
+                                               value
+                                               {:value-fn div-100})
+                                 ")")
+               :filter filter-rule})}
 
 
    {:id :drop-shadow
@@ -101,7 +108,8 @@
                         "xl" "drop-shadow(0 20px 13px rgb(0 0 0 / 0.03)) drop-shadow(0 8px 5px rgb(0 0 0 / 0.08))"
                         "2xl" "drop-shadow(0 25px 25px rgb(0 0 0 / 0.15))"
                         "none" "drop-shadow(0 0 #0000)")]
-                {:filter v}))}
+                {:--gi-drop-shadow v
+                 :filter filter-rule}))}
 
 
    {:id :grayscale
@@ -109,15 +117,17 @@
     grayscale = <'grayscale'> (<'-'> (number | fraction))?
     "
     :garden (fn [{[value] :component-data}]
-              (if (nil? value)
-                {:filter "grayscale(100%)"}
-                {:filter (str "grayscale("
-                              (value-unit->css value
-                                               {:number {:unit "%"
-                                                         :zero-unit nil}
-                                                :fraction {:unit "%"
-                                                           :value-fn mul-100}})
-                              ")")}))}
+              {:filter filter-rule
+               :--gi-grayscale
+               (str "grayscale("
+                    (if (nil? value)
+                      "100%"
+                      (value-unit->css value
+                                       {:number {:unit "%"
+                                                 :zero-unit nil}
+                                        :fraction {:unit "%"
+                                                   :value-fn mul-100}}))
+                    ")")})}
 
 
    {:id :hue-rotate
@@ -125,9 +135,10 @@
     hue-rotate = <'hue-rotate-'> number
     "
     :garden (fn [{[value] :component-data}]
-              {:filter (str "hue-rotate("
-                            (value-unit->css value {:number {:unit "deg"}})
-                            ")")})}
+              {:--gi-hue-rotate (str "hue-rotate("
+                                     (value-unit->css value {:number {:unit "deg"}})
+                                     ")")
+               :filter filter-rule})}
 
    {:id :mix-blend-mode
     :rules "

--- a/lib/girouette/src/girouette/tw/effect.cljc
+++ b/lib/girouette/src/girouette/tw/effect.cljc
@@ -120,6 +120,15 @@
                               ")")}))}
 
 
+   {:id :hue-rotate
+    :rules "
+    hue-rotate = <'hue-rotate-'> number
+    "
+    :garden (fn [{[value] :component-data}]
+              {:filter (str "hue-rotate("
+                            (value-unit->css value {:number {:unit "deg"}})
+                            ")")})}
+
    {:id :mix-blend-mode
     :rules "
     <mix-blend-mode-value> =

--- a/lib/girouette/src/girouette/tw/effect.cljc
+++ b/lib/girouette/src/girouette/tw/effect.cljc
@@ -87,6 +87,23 @@
                             ")")})}
 
 
+   {:id :drop-shadow
+    :rules "
+    drop-shadow = <'drop-shadow'> (<'-'> drop-shadow-value)?
+    <drop-shadow-value> = 'sm' | 'md' | 'lg' | 'xl' | '2xl' | 'none'
+    "
+    :garden (fn [{[value] :component-data}]
+              (let [v (case value
+                        nil "drop-shadow(0 1px 2px rgb(0 0 0 / 0.1)) drop-shadow(0 1px 1px rgb(0 0 0 / 0.06))"
+                        "sm" "drop-shadow(0 1px 1px rgb(0 0 0 / 0.05))"
+                        "md" "drop-shadow(0 4px 3px rgb(0 0 0 / 0.07)) drop-shadow(0 2px 2px rgb(0 0 0 / 0.06))"
+                        "lg" "drop-shadow(0 10px 8px rgb(0 0 0 / 0.04)) drop-shadow(0 4px 3px rgb(0 0 0 / 0.1))"
+                        "xl" "drop-shadow(0 20px 13px rgb(0 0 0 / 0.03)) drop-shadow(0 8px 5px rgb(0 0 0 / 0.08))"
+                        "2xl" "drop-shadow(0 25px 25px rgb(0 0 0 / 0.15))"
+                        "none" "drop-shadow(0 0 #0000)")]
+                {:filter v}))}
+
+
    {:id :mix-blend-mode
     :rules "
     <mix-blend-mode-value> =

--- a/lib/girouette/src/girouette/tw/effect.cljc
+++ b/lib/girouette/src/girouette/tw/effect.cljc
@@ -171,4 +171,26 @@
     opacity = <'opacity-'> number
     "
     :garden (fn [{[value] :component-data}]
-              {:opacity (value-unit->css value {:value-fn div-100})})}])
+              {:opacity (value-unit->css value {:value-fn div-100})})}
+
+
+   {:id :saturate
+    :rules "
+    saturate = <'saturate-'> number
+    "
+    :garden (fn [{[value] :component-data}]
+              {:--gi-saturate (str "saturate("
+                                   (value-unit->css value {:value-fn div-100})
+                                   ")")
+               :filter filter-rule})}
+
+   {:id :sepia
+    :rules "
+    sepia = <'sepia'> (<'-'> number)?
+    "
+    :garden (fn [{[value] :component-data}]
+              {:--gi-sepia (str "sepia("
+                                (value-unit->css value {:number {:unit "%"}})
+                                ")")
+               :filter filter-rule})
+    }])

--- a/lib/girouette/src/girouette/tw/effect.cljc
+++ b/lib/girouette/src/girouette/tw/effect.cljc
@@ -76,6 +76,17 @@
                                   "var(--gi-shadow)")}))}
 
 
+   {:id :contrast
+    :rules "
+    contrast = <'contrast-'> number
+    "
+    :garden (fn [{[value] :component-data}]
+              {:filter (str "contrast(" (value-unit->css
+                                          value
+                                          {:value-fn div-100})
+                            ")")})}
+
+
    {:id :mix-blend-mode
     :rules "
     <mix-blend-mode-value> =

--- a/lib/girouette/src/girouette/tw/effect.cljc
+++ b/lib/girouette/src/girouette/tw/effect.cljc
@@ -2,11 +2,137 @@
   (:require [girouette.tw.common :refer [value-unit->css div-100 mul-100]]))
 
 (def ^:private filter-rule
-  "var(--gi-blur, ) var(--gi-brightness, ) var(--gi-contrast, ) var(--gi-grayscale, ) var(--gi-hue-rotate, ) var(--gi-invert, ) var(--gi-saturate, ) var(--gi-sepia, ) var(--gi-drop-shadow, )"
-  )
+  "var(--gi-blur, ) var(--gi-brightness, ) var(--gi-contrast, ) var(--gi-grayscale, ) var(--gi-hue-rotate, ) var(--gi-invert, ) var(--gi-saturate, ) var(--gi-sepia, ) var(--gi-drop-shadow, )")
+
+(def ^:private backdrop-filter-rule
+  "var(--gi-backdrop-blur) var(--gi-backdrop-brightness) var(--gi-backdrop-contrast) var(--gi-backdrop-grayscale) var(--gi-backdrop-hue-rotate) var(--gi-backdrop-invert) var(--gi-backdrop-opacity) var(--gi-backdrop-saturate) var(--gi-backdrop-sepia)")
 
 (def components
-  [{:id :background-blend-mode
+  [{:id :backdrop-blur
+    :rules "
+    backdrop-blur = <'backdrop-blur'> (<'-'> ( backdrop-blur-value-fix |
+                                               backdrop-blur-value-number ))?
+    backdrop-blur-value-fix = 'sm' | 'md' | 'lg' | 'xl' | '2xl' | '3xl' | 'none'
+    backdrop-blur-value-number = length
+    "
+    :garden (fn [{value :component-data}]
+              (let [blur (if (empty? value)
+                           "8px"
+                           (let [{:keys [backdrop-blur-value-number
+                                         backdrop-blur-value-fix]}
+                                 (into {} value)]
+                             (if backdrop-blur-value-number
+                               (value-unit->css backdrop-blur-value-number {})
+                               ({"sm" "4px"
+                                 "md" "12px"
+                                 "lg" "16px"
+                                 "xl" "24px"
+                                 "2xl" "40px"
+                                 "3xl" "64px"
+                                 "none" "0"} backdrop-blur-value-fix))))]
+                {:--gi-backdrop-blur (str "blur(" blur ")")
+                 :backdrop-filter backdrop-filter-rule}))}
+
+
+   {:id :backdrop-brightness
+    :rules "
+    backdrop-brightness = <'backdrop-brightness-'> number
+    "
+    :garden (fn [{[value] :component-data}]
+              {:--gi-backdrop-brightness (str "brightness(" (value-unit->css
+                                                              value
+                                                              {:value-fn div-100})
+                                              ")")
+               :backdrop-filter backdrop-filter-rule})}
+
+
+   {:id :backdrop-contrast
+    :rules "
+    backdrop-contrast = <'backdrop-contrast-'> number
+    "
+    :garden (fn [{[value] :component-data}]
+              {:--gi-backdrop-contrast (str "contrast(" (value-unit->css
+                                                          value
+                                                          {:value-fn div-100})
+                                            ")")
+               :backdrop-filter backdrop-filter-rule})}
+
+
+   {:id :backdrop-grayscale
+    :rules "
+    backdrop-grayscale = <'backdrop-grayscale'> (<'-'> (number | fraction))?
+    "
+    :garden (fn [{[value] :component-data}]
+              {:backdrop-filter backdrop-filter-rule
+               :--gi-backdrop-grayscale
+               (str "grayscale("
+                    (if (nil? value)
+                      "100%"
+                      (value-unit->css value
+                                       {:number {:unit "%"
+                                                 :zero-unit nil}
+                                        :fraction {:unit "%"
+                                                   :value-fn mul-100}}))
+                    ")")})}
+
+   {:id :backdrop-hue-rotate
+    :rules "
+    backdrop-hue-rotate = <'backdrop-hue-rotate-'> number
+    "
+    :garden (fn [{[value] :component-data}]
+              {:--gi-backdrop-hue-rotate (str "hue-rotate("
+                                              (value-unit->css value
+                                                               {:number {:unit "deg"}})
+                                              ")")
+               :backdrop-filter backdrop-filter-rule})}
+
+   {:id :backdrop-invert
+    :rules "
+    backdrop-invert = <'backdrop-invert'> (<'-'> number )?
+    "
+    :garden (fn [{[value] :component-data}]
+              {:--gi-backdrop-invert (str "invert("
+                                          (if (nil? value)
+                                            "100%"
+                                            (value-unit->css value {:number {:unit "%"}}))
+                                          ")")
+               :backdrop-filter backdrop-filter-rule})}
+
+
+   {:id :backdrop-opacity
+    :rules "
+    backdrop-opacity = <'backdrop-opacity-'> number
+    "
+    :garden (fn [{[value] :component-data}]
+              {:--gi-backdrop-opacity (str "opacity("
+                                           (value-unit->css value {:value-fn div-100})
+                                           ")")
+               :backdrop-filter backdrop-filter-rule})}
+
+
+   {:id :backdrop-saturate
+    :rules "
+    backdrop-saturate = <'backdrop-saturate-'> number
+    "
+    :garden (fn [{[value] :component-data}]
+              {:--gi-backdrop-saturate (str "saturate("
+                                            (value-unit->css value {:value-fn div-100})
+                                            ")")
+               :backdrop-filter backdrop-filter-rule})}
+
+
+   {:id :backdrop-sepia
+    :rules "
+    backdrop-sepia = <'backdrop-sepia'> (<'-'> number)?
+    "
+    :garden (fn [{[value] :component-data}]
+              {:--gi-backdrop-sepia (str "sepia("
+                                         (value-unit->css value {:number {:unit "%"}})
+                                         ")")
+               :backdrop-filter backdrop-filter-rule})}
+
+
+   {:id :background-blend-mode
     :rules "
     <background-blend-mode-value> =
                          'normal' | 'multiply' | 'screen' | 'overlay' |
@@ -88,9 +214,9 @@
     "
     :garden (fn [{[value] :component-data}]
               {:--gi-contrast (str "contrast(" (value-unit->css
-                                               value
-                                               {:value-fn div-100})
-                                 ")")
+                                                 value
+                                                 {:value-fn div-100})
+                                   ")")
                :filter filter-rule})}
 
 
@@ -146,10 +272,10 @@
     "
     :garden (fn [{[value] :component-data}]
               {:--gi-invert (str "invert("
-                            (if (nil? value)
-                              "100%"
-                              (value-unit->css value {:number {:unit "%"}}))
-                            ")")
+                                 (if (nil? value)
+                                   "100%"
+                                   (value-unit->css value {:number {:unit "%"}}))
+                                 ")")
                :filter filter-rule})}
 
 
@@ -192,5 +318,5 @@
               {:--gi-sepia (str "sepia("
                                 (value-unit->css value {:number {:unit "%"}})
                                 ")")
-               :filter filter-rule})
-    }])
+               :filter filter-rule})}
+   ])

--- a/lib/girouette/src/girouette/tw/effect.cljc
+++ b/lib/girouette/src/girouette/tw/effect.cljc
@@ -16,6 +16,29 @@
               {:background-blend-mode blend-mode})}
 
 
+   {:id :blur
+    :rules "
+    blur = <'blur'> (<'-'> ( blur-value-fix | blur-value-number ))?
+    blur-value-fix = 'sm' | 'md' | 'lg' | 'xl' | '2xl' | '3xl' | 'none'
+    blur-value-number = length
+    "
+    :garden (fn [{value :component-data}]
+              (let [blur (if (empty? value)
+                           "8px"
+                           (let [{:keys [blur-value-number blur-value-fix]}
+                                 (into {} value)]
+                             (if blur-value-number
+                               (value-unit->css blur-value-number {})
+                               ({"sm" "4px"
+                                 "md" "12px"
+                                 "lg" "16px"
+                                 "xl" "24px"
+                                 "2xl" "40px"
+                                 "3xl" "64px"
+                                 "none" "0"} blur-value-fix))))]
+                {:filter (str "blur(" blur ")")}))}
+
+
    {:id :box-shadow
     :rules "
     box-shadow = <'shadow'> (<'-'> box-shadow-value)?

--- a/lib/girouette/src/girouette/tw/flexbox.cljc
+++ b/lib/girouette/src/girouette/tw/flexbox.cljc
@@ -28,7 +28,7 @@
 
    {:id :flex-basis
     :rules "
-    flex-basis = <'flex-basis'> (<'-'> flex-basis-value)?
+    flex-basis = <'flex-'>? <'basis'> (<'-'> flex-basis-value)?
     flex-basis-value = number | length | length-unit | fraction | percentage | full-100% | auto
     "
     :garden (fn [{data :component-data}]

--- a/lib/girouette/src/girouette/tw/flexbox.cljc
+++ b/lib/girouette/src/girouette/tw/flexbox.cljc
@@ -4,7 +4,7 @@
 (def components
   [{:id :flex-grow
     :rules "
-    flex-grow = <'flex-grow'> (<'-'> flex-grow-value)?
+    flex-grow = <'flex-'>? <'grow'> (<'-'> flex-grow-value)?
     flex-grow-value = number | fraction
     "
     :garden (fn [{data :component-data}]
@@ -16,7 +16,7 @@
 
    {:id :flex-shrink
     :rules "
-    flex-shrink = <'flex-shrink'> (<'-'> flex-shrink-value)?
+    flex-shrink = <'flex-'>? <'shrink'> (<'-'> flex-shrink-value)?
     flex-shrink-value = number | fraction
     "
     :garden (fn [{data :component-data}]

--- a/lib/girouette/src/girouette/tw/interactivity.cljc
+++ b/lib/girouette/src/girouette/tw/interactivity.cljc
@@ -71,4 +71,13 @@
     user-select = <'select-'> ('none' | 'text' | 'all' | 'auto')
     "
     :garden (fn [{[type] :component-data}]
-              {:user-select type})}])
+              {:user-select type})}
+
+   {:id :will-change
+    :rules "
+    will-change = <'will-change-'> ( 'auto' | 'scroll' | 'contents' | 'transform' )
+    "
+    :garden (fn [{[value] :component-data}]
+              {:will-change (if (= value "scroll")
+                              "scroll-position"
+                              value)})}])

--- a/lib/girouette/src/girouette/tw/interactivity.cljc
+++ b/lib/girouette/src/girouette/tw/interactivity.cljc
@@ -1,7 +1,19 @@
-(ns ^:no-doc girouette.tw.interactivity)
+(ns ^:no-doc girouette.tw.interactivity
+  (:require
+   [girouette.tw.color :refer [color->css]]))
 
 (def components
-  [{:id :appearance
+  [{:id :accent-color
+    :rules "
+    accent-color = <'accent-'> ( 'inherit' | 'current' | color )
+    "
+    :garden (fn [{[color] :component-data read-color :read-color}]
+              {:accent-color (case color
+                               "inherit" "inherit"
+                               "current" "currentColor"
+                               (color->css (read-color color)))})}
+
+   {:id :appearance
     :rules "
     appearance = 'appearance-none'
     "

--- a/lib/girouette/src/girouette/tw/interactivity.cljc
+++ b/lib/girouette/src/girouette/tw/interactivity.cljc
@@ -12,7 +12,7 @@
    {:id :cursor
     :rules "
     cursor = <'cursor-'> ('auto' | 'default' | 'pointer' | 'wait' |
-                          'text' | 'move' | 'not-allowed')
+                          'text' | 'move' | 'not-allowed' | 'help' )
     "
     :garden (fn [{[type] :component-data}]
               {:cursor type})}

--- a/lib/girouette/src/girouette/tw/interactivity.cljc
+++ b/lib/girouette/src/girouette/tw/interactivity.cljc
@@ -66,6 +66,15 @@
     :garden (fn [{[value] :component-data}]
               {:scroll-behavior value})}
 
+   {:id :touch-action
+    :rules "
+    touch-action = <'touch-'> ( 'auto' | 'none' | 'pan-x' | 'pan-y' |
+                                'pan-left' | 'pan-right' | 'pan-up' | 'pan-down' |
+                                'pinch-zoom' | 'manipulation' )
+    "
+    :garden (fn [{[value] :component-data}]
+              {:touch-action value})}
+
    {:id :user-select
     :rules "
     user-select = <'select-'> ('none' | 'text' | 'all' | 'auto')

--- a/lib/girouette/src/girouette/tw/interactivity.cljc
+++ b/lib/girouette/src/girouette/tw/interactivity.cljc
@@ -1,6 +1,7 @@
 (ns ^:no-doc girouette.tw.interactivity
   (:require
-   [girouette.tw.color :refer [color->css]]))
+   [girouette.tw.color :refer [color->css]]
+   [girouette.tw.common :refer [value-unit->css div-4]]))
 
 (def components
   [{:id :accent-color
@@ -65,6 +66,101 @@
     "
     :garden (fn [{[value] :component-data}]
               {:scroll-behavior value})}
+
+   {:id :scroll-snap-align
+    :rules "
+    scroll-snap-align = <'snap-'> ( 'start' | 'end' | 'center' | 'align-none' )
+    "
+    :garden (fn [{[value] :component-data}]
+              {:scroll-snap-align (if (= value "align-none")
+                                    "none"
+                                    value)})}
+
+   {:id :scroll-snap-stop
+    :rules "
+    scroll-snap-stop = <'snap-'> ( 'normal' | 'always' )
+    "
+    :garden (fn [{[value] :component-data}]
+              {:scroll-snap-stop value})}
+
+   {:id :scroll-snap-type
+    :rules "
+    scroll-snap-type = <'snap-'> ( scroll-snap-type-dir | scroll-snap-type-type )
+    scroll-snap-type-dir = 'none' | 'x' | 'y' | 'both'
+    scroll-snap-type-type = 'mandatory' | 'proxmity'
+    "
+    :garden (fn [{:keys [component-data]}]
+              (let [{:keys [scroll-snap-type-dir scroll-snap-type-type]}
+                    (into {} component-data)]
+                (cond
+                  scroll-snap-type-type
+                 {:--gi-scroll-snap-strictness scroll-snap-type-type}
+
+                 (= scroll-snap-type-dir "none")
+                 {:scroll-snap-type "none"}
+
+                 :else
+                 {:scroll-snap-type
+                  (str scroll-snap-type-dir
+                       " var(--gi-scroll-snap-strictness,proximity)")})))}
+
+   {:id :scroll-margin
+    :rules "
+    scroll-margin = signus? <'scroll-m'> (direction | axis)? <'-'> scroll-margin-value
+    scroll-margin-value = number | length | length-unit
+    "
+    :garden (fn [{:keys [component-data]}]
+              (let [{:keys [signus direction axis scroll-margin-value]}
+                    (into {} component-data)
+                    directions (case direction
+                                 "t" ["top"]
+                                 "r" ["right"]
+                                 "b" ["bottom"]
+                                 "l" ["left"]
+                                 (case axis
+                                   "x" ["left" "right"]
+                                   "y" ["top" "bottom"]
+                                   nil))
+                    value-css (value-unit->css scroll-margin-value
+                                               {:signus signus
+                                                :zero-unit "px"
+                                                :number {:unit "rem"
+                                                         :value-fn div-4}})]
+                (if (nil? directions)
+                  {:scroll-margin value-css}
+                  (into {}
+                        (map (fn [dir] [(keyword (str "scroll-margin-" dir))
+                                        value-css]))
+                        directions))))}
+
+   {:id :scroll-padding
+    :rules "
+    scroll-padding = signus? <'scroll-p'> (direction | axis)? <'-'> scroll-padding-value
+    scroll-padding-value = number | length | length-unit
+    "
+    :garden (fn [{:keys [component-data]}]
+              (let [{:keys [signus direction axis scroll-padding-value]}
+                    (into {} component-data)
+                    directions (case direction
+                                 "t" ["top"]
+                                 "r" ["right"]
+                                 "b" ["bottom"]
+                                 "l" ["left"]
+                                 (case axis
+                                   "x" ["left" "right"]
+                                   "y" ["top" "bottom"]
+                                   nil))
+                    value-css (value-unit->css scroll-padding-value
+                                               {:signus signus
+                                                :zero-unit "px"
+                                                :number {:unit "rem"
+                                                         :value-fn div-4}})]
+                (if (nil? directions)
+                  {:scroll-padding value-css}
+                  (into {}
+                        (map (fn [dir] [(keyword (str "scroll-padding-" dir))
+                                        value-css]))
+                        directions))))}
 
    {:id :touch-action
     :rules "

--- a/lib/girouette/src/girouette/tw/interactivity.cljc
+++ b/lib/girouette/src/girouette/tw/interactivity.cljc
@@ -31,17 +31,6 @@
               {:cursor type})}
 
 
-   {:id :outline
-    :rules "
-    outline = <'outline-'> ('none' | 'white' | 'black')
-    "
-    :garden (fn [{[type] :component-data}]
-              {:outline ({"none" "2px solid transparent"
-                          "white" "2px dotted white"
-                          "black" "2px dotted black"} type)
-               :outline-offset "2px"})}
-
-
    {:id :pointer-events
     :rules "
     pointer-events = <'pointer-events-'> ('none' | 'auto')

--- a/lib/girouette/src/girouette/tw/interactivity.cljc
+++ b/lib/girouette/src/girouette/tw/interactivity.cljc
@@ -59,6 +59,12 @@
                          "y" "vertical"
                          nil "both"} type)})}
 
+   {:id :scroll-behaviour
+    :rules "
+    scroll-behaviour = <'scroll-'> ( 'auto' | 'smooth' )
+    "
+    :garden (fn [{[value] :component-data}]
+              {:scroll-behavior value})}
 
    {:id :user-select
     :rules "

--- a/lib/girouette/src/girouette/tw/layout.cljc
+++ b/lib/girouette/src/girouette/tw/layout.cljc
@@ -51,6 +51,12 @@
     :garden (fn [{[direction] :component-data}]
               {:clear direction})}
 
+   {:id :isolation
+    :rules "
+    isolation = 'isolate' | <'isolation-'> 'auto'
+    "
+    :garden (fn [{[isolation] :component-data}]
+              {:isolation isolation})}
 
    {:id :object-fit
     :rules "

--- a/lib/girouette/src/girouette/tw/layout.cljc
+++ b/lib/girouette/src/girouette/tw/layout.cljc
@@ -27,8 +27,8 @@
     :rules "
     display = 'block' | 'inline-block' | 'inline' | 'flex' | 'inline-flex' |
         'table' | 'table-caption' | 'table-cell' | 'table-column' | 'table-column-group' |
-        'table-footer-group' | 'table-header-group' | 'table-row-group' | 'table-row' |
         'flow-root' | 'grid' |'inline-grid' | 'contents' | 'hidden'
+        'table-footer-group' | 'table-header-group' | 'table-row-group' | 'table-row' | 'inline-table' |
     "
     :garden (fn [{[display-mode] :component-data}]
               {:display (if (= "hidden" display-mode)

--- a/lib/girouette/src/girouette/tw/layout.cljc
+++ b/lib/girouette/src/girouette/tw/layout.cljc
@@ -27,8 +27,8 @@
     :rules "
     display = 'block' | 'inline-block' | 'inline' | 'flex' | 'inline-flex' |
         'table' | 'table-caption' | 'table-cell' | 'table-column' | 'table-column-group' |
-        'flow-root' | 'grid' |'inline-grid' | 'contents' | 'hidden'
         'table-footer-group' | 'table-header-group' | 'table-row-group' | 'table-row' | 'inline-table' |
+        'flow-root' | 'grid' |'inline-grid' | 'contents' | 'list-item' | 'hidden'
     "
     :garden (fn [{[display-mode] :component-data}]
               {:display (if (= "hidden" display-mode)

--- a/lib/girouette/src/girouette/tw/layout.cljc
+++ b/lib/girouette/src/girouette/tw/layout.cljc
@@ -21,6 +21,14 @@
                                  (->> (map read-number aspect-ratio-numbers)
                                       (str/join " / ")))}))}
 
+   {:id :break-before
+    :rules "
+    break-before = <'break-before-'> ( 'auto' | 'avoid' | 'all' | 'avoid-page' |
+                                       'page' | 'left' | 'right' | 'column' )
+    "
+    :garden (fn [{[value] :component-data}]
+              {:break-before value})}
+
    {:id :columns
     :rules "
     columns = <'columns-'> ( columns-number | columns-size | columns-auto )

--- a/lib/girouette/src/girouette/tw/layout.cljc
+++ b/lib/girouette/src/girouette/tw/layout.cljc
@@ -21,6 +21,36 @@
                                  (->> (map read-number aspect-ratio-numbers)
                                       (str/join " / ")))}))}
 
+   {:id :columns
+    :rules "
+    columns = <'columns-'> ( columns-number | columns-size | columns-auto )
+    columns-auto = 'auto'
+    columns-number = number
+    columns-size =  '3xs' | '2xs' | 'xs' | 'sm' | 'md' | 'lg' | 'xl' | '2xl' |
+                    '3xl' | '4xl' | '5xl' | '6xl' | '7xl'
+    "
+    :garden (fn [{:keys [component-data]}]
+              (let [{:keys [columns-number columns-size columns-auto]}
+                    (into {} component-data)]
+                {:columns (cond
+                            columns-auto "auto"
+                            columns-number (read-number columns-number)
+                            columns-size
+                            ({"3xs" "16rem"
+                              "2xs" "18rem"
+                              "xs"  "20rem"
+                              "sm"  "24rem"
+                              "md"  "28rem"
+                              "lg"  "32rem"
+                              "xl"  "36rem"
+                              "2xl" "42rem"
+                              "3xl" "48rem"
+                              "4xl" "56rem"
+                              "5xl" "64rem"
+                              "6xl" "72rem"
+                              "7xl" "80rem"} columns-size))}))}
+
+
    {:id :container
     :rules "
     container = <'container'>

--- a/lib/girouette/src/girouette/tw/layout.cljc
+++ b/lib/girouette/src/girouette/tw/layout.cljc
@@ -12,6 +12,12 @@
                 {:max-width (breakpoint->pixels media-query-min-width)}
                 {:width "100%"}))}
 
+   {:id :box-decoration-break
+    :rules "
+    box-decoration-break = <'box-decoration-'> ( 'clone' | 'slice' )
+    "
+    :garden (fn [{[decoration-break] :component-data}]
+              {:box-decoration-break decoration-break})}
 
    {:id :box-sizing
     :rules "

--- a/lib/girouette/src/girouette/tw/layout.cljc
+++ b/lib/girouette/src/girouette/tw/layout.cljc
@@ -142,7 +142,7 @@
    {:id :overflow
     :rules "
     overflow = <'overflow-'> (axis <'-'>)? overflow-mode
-    overflow-mode = 'auto' | 'hidden' | 'visible' | 'scroll'
+    overflow-mode = 'auto' | 'hidden' | 'visible' | 'scroll' | 'clip'
     "
     :garden (fn [{:keys [component-data]}]
               (let [{:keys [axis overflow-mode]} (into {} component-data)

--- a/lib/girouette/src/girouette/tw/layout.cljc
+++ b/lib/girouette/src/girouette/tw/layout.cljc
@@ -1,9 +1,27 @@
 (ns ^:no-doc girouette.tw.layout
   (:require [clojure.string :as str]
-            [girouette.tw.common :refer [value-unit->css breakpoint->pixels div-4 mul-100]]))
+            [girouette.tw.common :refer [value-unit->css breakpoint->pixels div-4 mul-100 read-number]]))
 
 (def components
-  [{:id :container
+  [{:id :aspect-ratio
+    :rules "
+    aspect-ratio = <'aspect-'> ( aspect-ratio-fixed | aspect-ratio-numbers )
+    aspect-ratio-fixed = 'auto' | 'square' | 'video'
+    aspect-ratio-numbers = number <'/'> number
+    "
+    :garden (fn [{:keys [component-data]}]
+              (let [{:keys [aspect-ratio-fixed aspect-ratio-numbers]}
+                    (into {} (map (fn [[k v1 v2]] (if v2 [k [v1 v2]] [k v1])))
+                          component-data)]
+                {:aspect-ratio (if (some? aspect-ratio-fixed)
+                                 (case aspect-ratio-fixed
+                                   "auto" "auto"
+                                   "square" "1 / 1"
+                                   "video" "16 / 9")
+                                 (->> (map read-number aspect-ratio-numbers)
+                                      (str/join " / ")))}))}
+
+   {:id :container
     :rules "
     container = <'container'>
     "

--- a/lib/girouette/src/girouette/tw/sizing.cljc
+++ b/lib/girouette/src/girouette/tw/sizing.cljc
@@ -5,7 +5,7 @@
   [{:id :width
     :rules "
     width = <'w-'> (number | length | length-unit | fraction | percentage | full-100% |
-                    auto | screen-100vw | min-content | max-content)
+                    auto | screen-100vw | min-content | max-content | fit-content)
     "
     :garden (fn [{[value-data] :component-data}]
               {:width (value-unit->css value-data
@@ -19,7 +19,7 @@
    {:id :min-width
     :rules "
     min-width = <'min-w-'> (number | length | length-unit | fraction | percentage | full-100% |
-                            auto | screen-100vw | min-content | max-content)
+                            auto | screen-100vw | min-content | max-content | fit-content)
     "
     :garden (fn [{[value-data] :component-data}]
               {:min-width (value-unit->css value-data
@@ -36,7 +36,7 @@
     max-width-fixed-size = 'xs' | 'sm' | 'md' | 'lg' | 'xl' | '2xl' | '3xl' | '4xl' | '5xl' | '6xl' | '7xl' |
                            'prose' | 'screen-sm' | 'screen-md' | 'screen-lg' | 'screen-xl' | 'screen-2xl'
     max-width-generic-size = number | length | length-unit | fraction | percentage | full-100% |
-                             none | screen-100vw | min-content | max-content
+                             none | screen-100vw | min-content | max-content | fit-content
     "
     :garden (fn [{:keys [component-data]}]
               (let [{:keys [max-width-fixed-size max-width-generic-size]} (into {} component-data)]
@@ -69,7 +69,7 @@
    {:id :height
     :rules "
     height = <'h-'> (number | length | length-unit | fraction | percentage | full-100% |
-                     auto | screen-100vh | min-content | max-content)
+                     auto | screen-100vh | min-content | max-content | fit-content)
     "
     :garden (fn [{[value-data] :component-data}]
               {:height (value-unit->css value-data
@@ -83,7 +83,7 @@
    {:id :min-height
     :rules "
     min-height = <'min-h-'> (number | length | length-unit | fraction | percentage | full-100% |
-                             auto | screen-100vh | min-content | max-content)
+                             auto | screen-100vh | min-content | max-content | fit-content)
     "
     :garden (fn [{[value-data] :component-data}]
               {:min-height (value-unit->css value-data
@@ -97,7 +97,7 @@
    {:id :max-height
     :rules "
     max-height = <'max-h-'> (number | length | length-unit | fraction | percentage | full-100% |
-                             none | screen-100vh | min-content | max-content)
+                             none | screen-100vh | min-content | max-content | fit-content)
     "
     :garden (fn [{[value-data] :component-data}]
               {:max-height (value-unit->css value-data

--- a/lib/girouette/src/girouette/tw/typography.cljc
+++ b/lib/girouette/src/girouette/tw/typography.cljc
@@ -28,7 +28,20 @@
 
 
 (def components
-  [{:id :font-family
+  [{:id :content
+    :rules "
+    content = <'content-'> <'['> #'[^\\] ]*' <']'>
+    "
+    :garden (fn [{[value] :component-data}]
+              {:content (-> value
+                            ;; negative-lookbehind isn't supported in javascript
+                            (str/replace #"(^|[^\\])'" "$1\"")
+                            (str/replace #"\\'" "'")
+                            (str/replace #"(^|[^\\])_" "$1 ")
+                            (str/replace #"\\_" "_"))})}
+
+
+   {:id :font-family
     :rules "
     font-family = <'font-'> font-family-name
     "

--- a/lib/girouette/src/girouette/tw/typography.cljc
+++ b/lib/girouette/src/girouette/tw/typography.cljc
@@ -272,6 +272,31 @@
                                         value
                                         (color->css (read-color value)))})}
 
+   {:id :text-decoration-style
+    :rules "
+    text-decoration-style = <'decoration-'> ( 'solid' | 'double' | 'dotted' |
+                                              'dashed' | 'wavy' )
+    "
+    :garden (fn [{[value] :component-data}]
+              {:text-decoration-style value})}
+
+   {:id :text-decoration-thickness
+    :rules "
+    text-decoration-thickness = <'decoration-'> ( text-decoration-thickness-from | text-decoration-thickness-value )
+    text-decoration-thickness-from = 'from-font'
+    text-decoration-thickness-value = auto | number | length | fraction | percentage
+    "
+    :garden (fn [{:keys [component-data]}]
+              (let [{:keys [text-decoration-thickness-from
+                            text-decoration-thickness-value]}
+                    (into {} component-data)]
+                {:text-decoration-thickness
+                 (if text-decoration-thickness-from
+                   "from-font"
+                   (value-unit->css text-decoration-thickness-value
+                                    {:number {:unit "px"}
+                                     :fraction {:unit "%"
+                                                :value-fn mul-100}}))}))}
 
    {:id :text-transform
     :rules "
@@ -296,6 +321,16 @@
                 "text-ellipsis" {:text-overflow "ellipsis"}
                 "text-clip" {:text-overflow "clip"}))}
 
+   {:id :text-underline-offset
+    :rules "
+    text-underline-offset = <'underline-'> (auto | number | length | fraction | percentage)
+    "
+    :garden (fn [{[value] :component-data}]
+              {:text-underline-offset
+               (value-unit->css value
+                                {:number {:unit "px"}
+                                 :fraction {:unit "%"
+                                            :value-fn mul-100}})})}
 
    {:id :vertical-alignment
     :rules "

--- a/lib/girouette/src/girouette/tw/typography.cljc
+++ b/lib/girouette/src/girouette/tw/typography.cljc
@@ -290,7 +290,7 @@
 
    {:id :vertical-alignment
     :rules "
-    vertical-alignment = <'align-'> ('baseline' | 'top' | 'middle' | 'bottom' | 'text-top' | 'text-bottom')
+    vertical-alignment = <'align-'> ('baseline' | 'top' | 'middle' | 'bottom' | 'text-top' | 'text-bottom' | 'sub' | 'super')
     "
     :garden (fn [{[align] :component-data}]
               {:vertical-align align})}

--- a/lib/girouette/src/girouette/tw/typography.cljc
+++ b/lib/girouette/src/girouette/tw/typography.cljc
@@ -121,7 +121,6 @@
     :garden (fn [{[variant-numeric] :component-data}]
               {:font-variant-numeric variant-numeric})}
 
-
    {:id :letter-spacing
     :rules "
     letter-spacing = <'tracking-'> ('tighter' | 'tight' | 'normal' |
@@ -232,6 +231,19 @@
                       {:--gi-text-opacity 1
                        :color (color->css [r g b "var(--gi-text-opacity)"])})))))
     :before-rules #{:text-opacity}}
+
+
+   {:id :text-indent
+    :rules "
+    text-indent = <'indent-'> ( number | length | fraction )
+    "
+    :garden (fn [{[value-data] :component-data}]
+              {:text-indent (value-unit->css value-data
+                                             {:zero-unit "px"
+                                              :number {:unit "rem"
+                                                       :value-fn div-4}
+                                              :fraction {:unit "%"
+                                                         :value-fn mul-100}})})}
 
 
    {:id :text-opacity

--- a/lib/girouette/src/girouette/tw/typography.cljc
+++ b/lib/girouette/src/girouette/tw/typography.cljc
@@ -277,15 +277,15 @@
 
    {:id :text-overflow
     :rules "
-    text-overflow = 'truncate' | 'overflow-ellipsis' | 'overflow-clip'
+    text-overflow = 'truncate' | 'text-ellipsis' | 'text-clip'
     "
     :garden (fn [{[overflow] :component-data}]
               (case overflow
                 "truncate" {:overflow "hidden"
                             :text-overflow "ellipsis"
                             :white-space "nowrap"}
-                "overflow-ellipsis" {:text-overflow "ellipsis"}
-                "overflow-clip" {:text-overflow "clip"}))}
+                "text-ellipsis" {:text-overflow "ellipsis"}
+                "text-clip" {:text-overflow "clip"}))}
 
 
    {:id :vertical-alignment

--- a/lib/girouette/src/girouette/tw/typography.cljc
+++ b/lib/girouette/src/girouette/tw/typography.cljc
@@ -263,6 +263,15 @@
                                   "line-through" "line-through"
                                   "no-underline" "none"} decoration)})}
 
+   {:id :text-decoration-color
+    :rules "
+    text-decoration-color = <'decoration-'> ( 'inherit' | color )
+    "
+    :garden (fn [{[value] :component-data read-color :read-color}]
+              {:text-decoration-color (if (= value "inherit")
+                                        value
+                                        (color->css (read-color value)))})}
+
 
    {:id :text-transform
     :rules "

--- a/lib/girouette/test/girouette/tw/background_test.cljc
+++ b/lib/girouette/test/girouette/tw/background_test.cljc
@@ -37,6 +37,15 @@
     "bg-gradient-to-tr"
     [".bg-gradient-to-tr" {:background-image "linear-gradient(to top right,var(--gi-gradient-stops))"}]
 
+    "bg-origin-border"
+    [".bg-origin-border" {:background-origin "border-box"}]
+
+    "bg-origin-padding"
+    [".bg-origin-padding" {:background-origin "padding-box"}]
+
+    "bg-origin-content"
+    [".bg-origin-content" {:background-origin "content-box"}]
+
     "from-blue-500"
     [".from-blue-500" {:--gi-gradient-from "#3b82f6"
                        :--gi-gradient-stops "var(--gi-gradient-from),var(--gi-gradient-to,#3b82f600)"}]

--- a/lib/girouette/test/girouette/tw/border_test.cljc
+++ b/lib/girouette/test/girouette/tw/border_test.cljc
@@ -66,6 +66,9 @@
     "border-dotted"
     [".border-dotted" {:border-style "dotted"}]
 
+    "border-hidden"
+    [".border-hidden" {:border-style "hidden"}]
+
     ;; Divide Width
     "divide-x"
     [".divide-x" [#garden.selectors.CSSSelector{:selector "&>*+*"}

--- a/lib/girouette/test/girouette/tw/border_test.cljc
+++ b/lib/girouette/test/girouette/tw/border_test.cljc
@@ -38,6 +38,10 @@
     "border-b-2em"
     [".border-b-2em" {:border-bottom-width "2em"}]
 
+    "border-y-2em"
+    [".border-y-2em" {:border-top-width "2em"
+                      :border-bottom-width "2em"}]
+
     "border-3px"
     [".border-3px" {:border-width "3px"}]
 
@@ -52,6 +56,12 @@
     "border-t-green-300"
     [".border-t-green-300"
      {:--gi-border-opacity 1
+      :border-top-color "rgba(134,239,172,var(--gi-border-opacity))"}]
+
+    "border-y-green-300"
+    [".border-y-green-300"
+     {:--gi-border-opacity 1
+      :border-bottom-color "rgba(134,239,172,var(--gi-border-opacity))"
       :border-top-color "rgba(134,239,172,var(--gi-border-opacity))"}]
 
     "border-b-rgba-c0ffee50"

--- a/lib/girouette/test/girouette/tw/border_test.cljc
+++ b/lib/girouette/test/girouette/tw/border_test.cljc
@@ -49,6 +49,15 @@
     [".border-green-300" {:--gi-border-opacity 1
                           :border-color        "rgba(134,239,172,var(--gi-border-opacity))"}]
 
+    "border-t-green-300"
+    [".border-t-green-300"
+     {:--gi-border-opacity 1
+      :border-top-color "rgba(134,239,172,var(--gi-border-opacity))"}]
+
+    "border-b-rgba-c0ffee50"
+    [".border-b-rgba-c0ffee50" {:border-bottom-color "#c0ffee50"}]
+
+
     ;; Border Opacity
     "border-opacity-25"
     [".border-opacity-25" {:--gi-border-opacity 0.25}]

--- a/lib/girouette/test/girouette/tw/border_test.cljc
+++ b/lib/girouette/test/girouette/tw/border_test.cljc
@@ -111,6 +111,26 @@
     [".divide-double" [#garden.selectors.CSSSelector{:selector "&>*+*"}
      {:border-style "double"}]]
 
+    ;; Outline
+    "outline-none"
+    [".outline-none" {:outline "2px solid transparent"
+                      :outline-offset "2px"}]
+
+    "outline"
+    [".outline" {:outline-style "solid"}]
+
+    "outline-gray-100"
+    [".outline-gray-100" {:outline-color "#f4f4f5"}]
+
+    "outline-3"
+    [".outline-3" {:outline-width "3px"}]
+
+    "outline-1rem"
+    [".outline-1rem" {:outline-width "1rem"}]
+
+    "outline-offset-2"
+    [".outline-offset-2" {:outline-offset "2px"}]
+
     ;; Ring Width
     ;; TODO: Test for `*	box-shadow: 0 0 #0000;`
     "ring"

--- a/lib/girouette/test/girouette/tw/box_alignment_test.cljc
+++ b/lib/girouette/test/girouette/tw/box_alignment_test.cljc
@@ -21,6 +21,9 @@
     "items-baseline"
     [".items-baseline" {:align-items "baseline"}]
 
+    "self-baseline"
+    [".self-baseline" {:align-self "baseline"}]
+
     "self-center"
     [".self-center" {:align-self "center"}]
 

--- a/lib/girouette/test/girouette/tw/common_test.cljc
+++ b/lib/girouette/test/girouette/tw/common_test.cljc
@@ -102,6 +102,12 @@
     "group-hover:container"
     [".group:hover" [".group-hover\\:container" {:width "100%"}]]
 
+    "group-invalid:container"
+    [".group:invalid" [".group-invalid\\:container" {:width "100%"}]]
+
+    "group-odd:container"
+    [".group:nth-child(odd)" [".group-odd\\:container" {:width "100%"}]]
+
     "dark:container"
     #garden.types.CSSAtRule{:identifier :media
                             :value {:media-queries {:prefers-color-scheme "dark"}

--- a/lib/girouette/test/girouette/tw/common_test.cljc
+++ b/lib/girouette/test/girouette/tw/common_test.cljc
@@ -108,6 +108,13 @@
     "group-odd:container"
     [".group:nth-child(odd)" [".group-odd\\:container" {:width "100%"}]]
 
+    "peer-active:container"
+    [".peer:active ~ .peer-active\\:container" {:width "100%"}]
+
+    "peer-odd:container"
+    [".peer:nth-child(odd) ~ .peer-odd\\:container"
+     {:width "100%"}]
+
     "dark:container"
     #garden.types.CSSAtRule{:identifier :media
                             :value {:media-queries {:prefers-color-scheme "dark"}

--- a/lib/girouette/test/girouette/tw/common_test.cljc
+++ b/lib/girouette/test/girouette/tw/common_test.cljc
@@ -144,6 +144,11 @@
      [(keyword "&::file-selector-button")
       [:&:hover {:width "100%"}]]]
 
+    "open:bg-white"
+    [".open\\:bg-white"
+     [(keyword "&[open]") {:background-color "rgba(255,255,255,var(--gi-bg-opacity))"
+                           :--gi-bg-opacity 1}]]
+
     "hover:file:container"
     [".hover\\:file\\:container"
      [:&:hover

--- a/lib/girouette/test/girouette/tw/common_test.cljc
+++ b/lib/girouette/test/girouette/tw/common_test.cljc
@@ -135,6 +135,11 @@
                             :value {:media-queries {:prefers-reduced-motion "reduced"}
                                     :rules ([".motion-reduce\\:container" {:width "100%"}])}}
 
+    "landscape:container"
+    #garden.types.CSSAtRule{:identifier :media
+                            :value {:media-queries {:orientation "landscape"}
+                                    :rules ([".landscape\\:container" {:width "100%"}])}}
+
     "file:container"
     [".file\\:container"
      [(keyword "&::file-selector-button") {:width "100%"}]]

--- a/lib/girouette/test/girouette/tw/common_test.cljc
+++ b/lib/girouette/test/girouette/tw/common_test.cljc
@@ -194,3 +194,11 @@
 
     "before:ml-1"
     [".before\\:ml-1" [(keyword "&::before") {:margin-left "0.25rem"}]]))
+
+(deftest arbtrary-test
+  (are [class-name expected-garden]
+    (= expected-garden (class-name->garden class-name))
+
+    "hover:[mask-type:alpha]"
+    [".hover\\:\\[mask-type\\:alpha\\]"
+     [:&:hover {:mask-type "alpha"}]]))

--- a/lib/girouette/test/girouette/tw/common_test.cljc
+++ b/lib/girouette/test/girouette/tw/common_test.cljc
@@ -135,6 +135,20 @@
                             :value {:media-queries {:prefers-reduced-motion "reduced"}
                                     :rules ([".motion-reduce\\:container" {:width "100%"}])}}
 
+    "file:container"
+    [".file\\:container"
+     [(keyword "&::file-selector-button") {:width "100%"}]]
+
+    "file:hover:container"
+    [".file\\:hover\\:container"
+     [(keyword "&::file-selector-button")
+      [:&:hover {:width "100%"}]]]
+
+    "hover:file:container"
+    [".hover\\:file\\:container"
+     [:&:hover
+      [(keyword "&::file-selector-button") {:width "100%"}]]]
+
     "focus:container"
     [".focus\\:container" [:&:focus {:width "100%"}]]
 

--- a/lib/girouette/test/girouette/tw/common_test.cljc
+++ b/lib/girouette/test/girouette/tw/common_test.cljc
@@ -180,4 +180,12 @@
     "sm:first:focus:container"
     #garden.types.CSSAtRule{:identifier :media
                             :value {:media-queries {:min-width "640px"}
-                                    :rules ([".sm\\:first\\:focus\\:container" [:&:first-child [:&:focus {:max-width "640px"}]]])}}))
+                                    :rules ([".sm\\:first\\:focus\\:container" [:&:first-child [:&:focus {:max-width "640px"}]]])}}
+
+    "placeholder:text-red-500"
+    [".placeholder\\:text-red-500" [(keyword "&::placeholder")
+                                    {:color "rgba(239,68,68,var(--gi-text-opacity))"
+                                     :--gi-text-opacity 1}]]
+
+    "before:ml-1"
+    [".before\\:ml-1" [(keyword "&::before") {:margin-left "0.25rem"}]]))

--- a/lib/girouette/test/girouette/tw/effect_test.cljc
+++ b/lib/girouette/test/girouette/tw/effect_test.cljc
@@ -36,6 +36,14 @@
     "contrast-150"
     [".contrast-150" {:filter "contrast(1.5)"}]
 
+    "drop-shadow"
+    [".drop-shadow"
+     {:filter "drop-shadow(0 1px 2px rgb(0 0 0 / 0.1)) drop-shadow(0 1px 1px rgb(0 0 0 / 0.06))"}]
+
+    "drop-shadow-lg"
+    [".drop-shadow-lg"
+     {:filter "drop-shadow(0 10px 8px rgb(0 0 0 / 0.04)) drop-shadow(0 4px 3px rgb(0 0 0 / 0.1))"}]
+
     "mix-blend-normal"
     [".mix-blend-normal" {:mix-blend-mode "normal"}]
     "mix-blend-multiply"

--- a/lib/girouette/test/girouette/tw/effect_test.cljc
+++ b/lib/girouette/test/girouette/tw/effect_test.cljc
@@ -44,6 +44,15 @@
     [".drop-shadow-lg"
      {:filter "drop-shadow(0 10px 8px rgb(0 0 0 / 0.04)) drop-shadow(0 4px 3px rgb(0 0 0 / 0.1))"}]
 
+    "grayscale"
+    [".grayscale" {:filter "grayscale(100%)"}]
+
+    "grayscale-0"
+    [".grayscale-0" {:filter "grayscale(0)"}]
+
+    "grayscale-1/2"
+    [".grayscale-1\\/2" {:filter "grayscale(50%)"}]
+
     "mix-blend-normal"
     [".mix-blend-normal" {:mix-blend-mode "normal"}]
     "mix-blend-multiply"

--- a/lib/girouette/test/girouette/tw/effect_test.cljc
+++ b/lib/girouette/test/girouette/tw/effect_test.cljc
@@ -6,6 +6,18 @@
   (are [class-name expected-garden]
     (= expected-garden (class-name->garden class-name))
 
+    "blur-none"
+    [".blur-none" {:filter "blur(0)"}]
+
+    "blur"
+    [".blur" {:filter "blur(8px)"}]
+
+    "blur-lg"
+    [".blur-lg" {:filter "blur(16px)"}]
+
+    "blur-1rem"
+    [".blur-1rem" {:filter "blur(1rem)"}]
+
     "mix-blend-normal"
     [".mix-blend-normal" {:mix-blend-mode "normal"}]
     "mix-blend-multiply"

--- a/lib/girouette/test/girouette/tw/effect_test.cljc
+++ b/lib/girouette/test/girouette/tw/effect_test.cljc
@@ -6,6 +6,72 @@
   (are [class-name expected-garden]
     (= expected-garden (class-name->garden class-name))
 
+    "mix-blend-normal"
+    [".mix-blend-normal" {:mix-blend-mode "normal"}]
+    "mix-blend-multiply"
+    [".mix-blend-multiply" {:mix-blend-mode "multiply"}]
+    "mix-blend-screen"
+    [".mix-blend-screen" {:mix-blend-mode "screen"}]
+    "mix-blend-overlay"
+    [".mix-blend-overlay" {:mix-blend-mode "overlay"}]
+    "mix-blend-darken"
+    [".mix-blend-darken" {:mix-blend-mode "darken"}]
+    "mix-blend-lighten"
+    [".mix-blend-lighten" {:mix-blend-mode "lighten"}]
+    "mix-blend-color-dodge"
+    [".mix-blend-color-dodge" {:mix-blend-mode "color-dodge"}]
+    "mix-blend-color-burn"
+    [".mix-blend-color-burn" {:mix-blend-mode "color-burn"}]
+    "mix-blend-hard-light"
+    [".mix-blend-hard-light" {:mix-blend-mode "hard-light"}]
+    "mix-blend-soft-light"
+    [".mix-blend-soft-light" {:mix-blend-mode "soft-light"}]
+    "mix-blend-difference"
+    [".mix-blend-difference" {:mix-blend-mode "difference"}]
+    "mix-blend-exclusion"
+    [".mix-blend-exclusion" {:mix-blend-mode "exclusion"}]
+    "mix-blend-hue"
+    [".mix-blend-hue" {:mix-blend-mode "hue"}]
+    "mix-blend-saturation"
+    [".mix-blend-saturation" {:mix-blend-mode "saturation"}]
+    "mix-blend-color"
+    [".mix-blend-color" {:mix-blend-mode "color"}]
+    "mix-blend-luminosity"
+    [".mix-blend-luminosity" {:mix-blend-mode "luminosity"}]
+
+    "bg-blend-normal"
+    [".bg-blend-normal" {:background-blend-mode "normal"}]
+    "bg-blend-multiply"
+    [".bg-blend-multiply" {:background-blend-mode "multiply"}]
+    "bg-blend-screen"
+    [".bg-blend-screen" {:background-blend-mode "screen"}]
+    "bg-blend-overlay"
+    [".bg-blend-overlay" {:background-blend-mode "overlay"}]
+    "bg-blend-darken"
+    [".bg-blend-darken" {:background-blend-mode "darken"}]
+    "bg-blend-lighten"
+    [".bg-blend-lighten" {:background-blend-mode "lighten"}]
+    "bg-blend-color-dodge"
+    [".bg-blend-color-dodge" {:background-blend-mode "color-dodge"}]
+    "bg-blend-color-burn"
+    [".bg-blend-color-burn" {:background-blend-mode "color-burn"}]
+    "bg-blend-hard-light"
+    [".bg-blend-hard-light" {:background-blend-mode "hard-light"}]
+    "bg-blend-soft-light"
+    [".bg-blend-soft-light" {:background-blend-mode "soft-light"}]
+    "bg-blend-difference"
+    [".bg-blend-difference" {:background-blend-mode "difference"}]
+    "bg-blend-exclusion"
+    [".bg-blend-exclusion" {:background-blend-mode "exclusion"}]
+    "bg-blend-hue"
+    [".bg-blend-hue" {:background-blend-mode "hue"}]
+    "bg-blend-saturation"
+    [".bg-blend-saturation" {:background-blend-mode "saturation"}]
+    "bg-blend-color"
+    [".bg-blend-color" {:background-blend-mode "color"}]
+    "bg-blend-luminosity"
+    [".bg-blend-luminosity" {:background-blend-mode "luminosity"}]
+
     "shadow"
     [".shadow" {:--gi-shadow "0 1px 3px 0 rgba(0,0,0,0.1),0 1px 2px 0 rgba(0,0,0,0.06)"
                 :box-shadow "var(--gi-ring-offset-shadow,0 0 #0000),var(--gi-ring-shadow,0 0 #0000),var(--gi-shadow)"}]

--- a/lib/girouette/test/girouette/tw/effect_test.cljc
+++ b/lib/girouette/test/girouette/tw/effect_test.cljc
@@ -53,6 +53,9 @@
     "grayscale-1/2"
     [".grayscale-1\\/2" {:filter "grayscale(50%)"}]
 
+    "hue-rotate-30"
+    [".hue-rotate-30" {:filter "hue-rotate(30deg)"}]
+
     "mix-blend-normal"
     [".mix-blend-normal" {:mix-blend-mode "normal"}]
     "mix-blend-multiply"

--- a/lib/girouette/test/girouette/tw/effect_test.cljc
+++ b/lib/girouette/test/girouette/tw/effect_test.cljc
@@ -18,6 +18,15 @@
     "blur-1rem"
     [".blur-1rem" {:filter "blur(1rem)"}]
 
+    "brightness-0"
+    [".brightness-0" {:filter "brightness(0)"}]
+
+    "brightness-75"
+    [".brightness-75" {:filter "brightness(0.75)"}]
+
+    "brightness-150"
+    [".brightness-150" {:filter "brightness(1.5)"}]
+
     "mix-blend-normal"
     [".mix-blend-normal" {:mix-blend-mode "normal"}]
     "mix-blend-multiply"

--- a/lib/girouette/test/girouette/tw/effect_test.cljc
+++ b/lib/girouette/test/girouette/tw/effect_test.cljc
@@ -7,54 +7,70 @@
     (= expected-garden (class-name->garden class-name))
 
     "blur-none"
-    [".blur-none" {:filter "blur(0)"}]
+    [".blur-none" {:--gi-blur "blur(0)"
+                   :filter "var(--gi-blur, ) var(--gi-brightness, ) var(--gi-contrast, ) var(--gi-grayscale, ) var(--gi-hue-rotate, ) var(--gi-invert, ) var(--gi-saturate, ) var(--gi-sepia, ) var(--gi-drop-shadow, )"}]
 
     "blur"
-    [".blur" {:filter "blur(8px)"}]
+    [".blur" {:--gi-blur "blur(8px)"
+              :filter "var(--gi-blur, ) var(--gi-brightness, ) var(--gi-contrast, ) var(--gi-grayscale, ) var(--gi-hue-rotate, ) var(--gi-invert, ) var(--gi-saturate, ) var(--gi-sepia, ) var(--gi-drop-shadow, )"}]
 
     "blur-lg"
-    [".blur-lg" {:filter "blur(16px)"}]
+    [".blur-lg" {:--gi-blur "blur(16px)"
+                 :filter "var(--gi-blur, ) var(--gi-brightness, ) var(--gi-contrast, ) var(--gi-grayscale, ) var(--gi-hue-rotate, ) var(--gi-invert, ) var(--gi-saturate, ) var(--gi-sepia, ) var(--gi-drop-shadow, )"}]
 
     "blur-1rem"
-    [".blur-1rem" {:filter "blur(1rem)"}]
+    [".blur-1rem" {:--gi-blur "blur(1rem)"
+                   :filter "var(--gi-blur, ) var(--gi-brightness, ) var(--gi-contrast, ) var(--gi-grayscale, ) var(--gi-hue-rotate, ) var(--gi-invert, ) var(--gi-saturate, ) var(--gi-sepia, ) var(--gi-drop-shadow, )"}]
 
     "brightness-0"
-    [".brightness-0" {:filter "brightness(0)"}]
+    [".brightness-0" {:--gi-brightness "brightness(0)"
+                      :filter "var(--gi-blur, ) var(--gi-brightness, ) var(--gi-contrast, ) var(--gi-grayscale, ) var(--gi-hue-rotate, ) var(--gi-invert, ) var(--gi-saturate, ) var(--gi-sepia, ) var(--gi-drop-shadow, )"}]
 
     "brightness-75"
-    [".brightness-75" {:filter "brightness(0.75)"}]
+    [".brightness-75" {:--gi-brightness "brightness(0.75)"
+                       :filter "var(--gi-blur, ) var(--gi-brightness, ) var(--gi-contrast, ) var(--gi-grayscale, ) var(--gi-hue-rotate, ) var(--gi-invert, ) var(--gi-saturate, ) var(--gi-sepia, ) var(--gi-drop-shadow, )"}]
 
     "brightness-150"
-    [".brightness-150" {:filter "brightness(1.5)"}]
+    [".brightness-150" {:--gi-brightness "brightness(1.5)"
+                        :filter "var(--gi-blur, ) var(--gi-brightness, ) var(--gi-contrast, ) var(--gi-grayscale, ) var(--gi-hue-rotate, ) var(--gi-invert, ) var(--gi-saturate, ) var(--gi-sepia, ) var(--gi-drop-shadow, )"}]
 
     "contrast-0"
-    [".contrast-0" {:filter "contrast(0)"}]
+    [".contrast-0" {:--gi-contrast "contrast(0)"
+                    :filter "var(--gi-blur, ) var(--gi-brightness, ) var(--gi-contrast, ) var(--gi-grayscale, ) var(--gi-hue-rotate, ) var(--gi-invert, ) var(--gi-saturate, ) var(--gi-sepia, ) var(--gi-drop-shadow, )"}]
 
     "contrast-75"
-    [".contrast-75" {:filter "contrast(0.75)"}]
+    [".contrast-75" {:--gi-contrast "contrast(0.75)"
+                     :filter "var(--gi-blur, ) var(--gi-brightness, ) var(--gi-contrast, ) var(--gi-grayscale, ) var(--gi-hue-rotate, ) var(--gi-invert, ) var(--gi-saturate, ) var(--gi-sepia, ) var(--gi-drop-shadow, )"}]
 
     "contrast-150"
-    [".contrast-150" {:filter "contrast(1.5)"}]
+    [".contrast-150" {:--gi-contrast "contrast(1.5)"
+                      :filter "var(--gi-blur, ) var(--gi-brightness, ) var(--gi-contrast, ) var(--gi-grayscale, ) var(--gi-hue-rotate, ) var(--gi-invert, ) var(--gi-saturate, ) var(--gi-sepia, ) var(--gi-drop-shadow, )"}]
 
     "drop-shadow"
     [".drop-shadow"
-     {:filter "drop-shadow(0 1px 2px rgb(0 0 0 / 0.1)) drop-shadow(0 1px 1px rgb(0 0 0 / 0.06))"}]
+     {:--gi-drop-shadow "drop-shadow(0 1px 2px rgb(0 0 0 / 0.1)) drop-shadow(0 1px 1px rgb(0 0 0 / 0.06))"
+      :filter "var(--gi-blur, ) var(--gi-brightness, ) var(--gi-contrast, ) var(--gi-grayscale, ) var(--gi-hue-rotate, ) var(--gi-invert, ) var(--gi-saturate, ) var(--gi-sepia, ) var(--gi-drop-shadow, )"}]
 
     "drop-shadow-lg"
     [".drop-shadow-lg"
-     {:filter "drop-shadow(0 10px 8px rgb(0 0 0 / 0.04)) drop-shadow(0 4px 3px rgb(0 0 0 / 0.1))"}]
+     {:--gi-drop-shadow "drop-shadow(0 10px 8px rgb(0 0 0 / 0.04)) drop-shadow(0 4px 3px rgb(0 0 0 / 0.1))"
+      :filter "var(--gi-blur, ) var(--gi-brightness, ) var(--gi-contrast, ) var(--gi-grayscale, ) var(--gi-hue-rotate, ) var(--gi-invert, ) var(--gi-saturate, ) var(--gi-sepia, ) var(--gi-drop-shadow, )"}]
 
     "grayscale"
-    [".grayscale" {:filter "grayscale(100%)"}]
+    [".grayscale" {:--gi-grayscale "grayscale(100%)"
+                   :filter "var(--gi-blur, ) var(--gi-brightness, ) var(--gi-contrast, ) var(--gi-grayscale, ) var(--gi-hue-rotate, ) var(--gi-invert, ) var(--gi-saturate, ) var(--gi-sepia, ) var(--gi-drop-shadow, )"}]
 
     "grayscale-0"
-    [".grayscale-0" {:filter "grayscale(0)"}]
+    [".grayscale-0" {:--gi-grayscale "grayscale(0)"
+                     :filter "var(--gi-blur, ) var(--gi-brightness, ) var(--gi-contrast, ) var(--gi-grayscale, ) var(--gi-hue-rotate, ) var(--gi-invert, ) var(--gi-saturate, ) var(--gi-sepia, ) var(--gi-drop-shadow, )"}]
 
     "grayscale-1/2"
-    [".grayscale-1\\/2" {:filter "grayscale(50%)"}]
+    [".grayscale-1\\/2" {:--gi-grayscale "grayscale(50%)"
+                         :filter "var(--gi-blur, ) var(--gi-brightness, ) var(--gi-contrast, ) var(--gi-grayscale, ) var(--gi-hue-rotate, ) var(--gi-invert, ) var(--gi-saturate, ) var(--gi-sepia, ) var(--gi-drop-shadow, )"}]
 
     "hue-rotate-30"
-    [".hue-rotate-30" {:filter "hue-rotate(30deg)"}]
+    [".hue-rotate-30" {:--gi-hue-rotate "hue-rotate(30deg)"
+                       :filter "var(--gi-blur, ) var(--gi-brightness, ) var(--gi-contrast, ) var(--gi-grayscale, ) var(--gi-hue-rotate, ) var(--gi-invert, ) var(--gi-saturate, ) var(--gi-sepia, ) var(--gi-drop-shadow, )"}]
 
     "mix-blend-normal"
     [".mix-blend-normal" {:mix-blend-mode "normal"}]

--- a/lib/girouette/test/girouette/tw/effect_test.cljc
+++ b/lib/girouette/test/girouette/tw/effect_test.cljc
@@ -72,6 +72,14 @@
     [".hue-rotate-30" {:--gi-hue-rotate "hue-rotate(30deg)"
                        :filter "var(--gi-blur, ) var(--gi-brightness, ) var(--gi-contrast, ) var(--gi-grayscale, ) var(--gi-hue-rotate, ) var(--gi-invert, ) var(--gi-saturate, ) var(--gi-sepia, ) var(--gi-drop-shadow, )"}]
 
+    "invert"
+    [".invert" {:--gi-invert "invert(100%)"
+                :filter "var(--gi-blur, ) var(--gi-brightness, ) var(--gi-contrast, ) var(--gi-grayscale, ) var(--gi-hue-rotate, ) var(--gi-invert, ) var(--gi-saturate, ) var(--gi-sepia, ) var(--gi-drop-shadow, )"}]
+
+    "invert-0"
+    [".invert-0" {:--gi-invert "invert(0%)"
+                  :filter "var(--gi-blur, ) var(--gi-brightness, ) var(--gi-contrast, ) var(--gi-grayscale, ) var(--gi-hue-rotate, ) var(--gi-invert, ) var(--gi-saturate, ) var(--gi-sepia, ) var(--gi-drop-shadow, )"}]
+
     "mix-blend-normal"
     [".mix-blend-normal" {:mix-blend-mode "normal"}]
     "mix-blend-multiply"

--- a/lib/girouette/test/girouette/tw/effect_test.cljc
+++ b/lib/girouette/test/girouette/tw/effect_test.cljc
@@ -27,6 +27,15 @@
     "brightness-150"
     [".brightness-150" {:filter "brightness(1.5)"}]
 
+    "contrast-0"
+    [".contrast-0" {:filter "contrast(0)"}]
+
+    "contrast-75"
+    [".contrast-75" {:filter "contrast(0.75)"}]
+
+    "contrast-150"
+    [".contrast-150" {:filter "contrast(1.5)"}]
+
     "mix-blend-normal"
     [".mix-blend-normal" {:mix-blend-mode "normal"}]
     "mix-blend-multiply"

--- a/lib/girouette/test/girouette/tw/flexbox_test.cljc
+++ b/lib/girouette/test/girouette/tw/flexbox_test.cljc
@@ -6,6 +6,15 @@
   (are [class-name expected-garden]
     (= expected-garden (class-name->garden class-name))
 
+    "basis-3"
+    [".basis-3" {:flex-basis "0.75rem"}]
+
+    "basis-18px"
+    [".basis-18px" {:flex-basis "18px"}]
+
+    "basis-3/5"
+    [".basis-3\\/5" {:flex-basis "60%"}]
+
     "flex-grow"
     [".flex-grow" {:flex-grow 1}]
 

--- a/lib/girouette/test/girouette/tw/flexbox_test.cljc
+++ b/lib/girouette/test/girouette/tw/flexbox_test.cljc
@@ -18,6 +18,12 @@
     "flex-grow"
     [".flex-grow" {:flex-grow 1}]
 
+    "grow"
+    [".grow" {:flex-grow 1}]
+
+    "grow-0"
+    [".grow-0" {:flex-grow 0}]
+
     "flex-grow-3"
     [".flex-grow-3" {:flex-grow 3}]
 
@@ -29,6 +35,9 @@
 
     "flex-shrink-3"
     [".flex-shrink-3" {:flex-shrink 3}]
+
+    "shrink-3"
+    [".shrink-3" {:flex-shrink 3}]
 
     "flex-basis"
     [".flex-basis" {:flex-basis 1}]

--- a/lib/girouette/test/girouette/tw/interactivity_test.cljc
+++ b/lib/girouette/test/girouette/tw/interactivity_test.cljc
@@ -6,6 +6,12 @@
   (are [class-name expected-garden]
     (= expected-garden (class-name->garden class-name))
 
+    "accent-current"
+    [".accent-current" {:accent-color "currentColor"}]
+
+    "accent-#abcdef11"
+    [".accent-\\#abcdef11" {:accent-color "#abcdef11"}]
+
     "appearance-none"
     [".appearance-none" {:appearance "none"}]
 

--- a/lib/girouette/test/girouette/tw/interactivity_test.cljc
+++ b/lib/girouette/test/girouette/tw/interactivity_test.cljc
@@ -35,4 +35,10 @@
     [".resize-x" {:resize "horizontal"}]
 
     "select-all"
-    [".select-all" {:user-select "all"}]))
+    [".select-all" {:user-select "all"}]
+
+    "scroll-auto"
+    [".scroll-auto" {:scroll-behavior "auto"}]
+
+    "scroll-smooth"
+    [".scroll-smooth" {:scroll-behavior "smooth"}]))

--- a/lib/girouette/test/girouette/tw/interactivity_test.cljc
+++ b/lib/girouette/test/girouette/tw/interactivity_test.cljc
@@ -43,6 +43,12 @@
     "scroll-smooth"
     [".scroll-smooth" {:scroll-behavior "smooth"}]
 
+    "touch-auto"
+    [".touch-auto" {:touch-action "auto"}]
+
+    "touch-manipulation"
+    [".touch-manipulation" {:touch-action "manipulation"}]
+
     "will-change-auto"
     [".will-change-auto" {:will-change "auto"}]
 

--- a/lib/girouette/test/girouette/tw/interactivity_test.cljc
+++ b/lib/girouette/test/girouette/tw/interactivity_test.cljc
@@ -43,6 +43,48 @@
     "scroll-smooth"
     [".scroll-smooth" {:scroll-behavior "smooth"}]
 
+    "snap-normal"
+    [".snap-normal" {:scroll-snap-stop "normal"}]
+
+    "snap-start"
+    [".snap-start" {:scroll-snap-align "start"}]
+
+    "snap-align-none"
+    [".snap-align-none" {:scroll-snap-align "none"}]
+
+    "snap-x"
+    [".snap-x" {:scroll-snap-type "x var(--gi-scroll-snap-strictness,proximity)"}]
+
+    "snap-mandatory"
+    [".snap-mandatory" {:--gi-scroll-snap-strictness "mandatory"}]
+
+    "scroll-m-8"
+    [".scroll-m-8" {:scroll-margin "2rem"}]
+
+    "scroll-mt-8"
+    [".scroll-mt-8" {:scroll-margin-top "2rem"}]
+
+    "scroll-ml-0"
+    [".scroll-ml-0" {:scroll-margin-left "0px"}]
+
+    "scroll-my-11vh"
+    [".scroll-my-11vh" {:scroll-margin-top "11vh"
+                        :scroll-margin-bottom "11vh"}]
+
+    "scroll-mx-8"
+    [".scroll-mx-8" {:scroll-margin-left "2rem"
+                     :scroll-margin-right "2rem"}]
+
+    "scroll-p-8"
+    [".scroll-p-8" {:scroll-padding "2rem"}]
+
+    "scroll-pt-8"
+    [".scroll-pt-8" {:scroll-padding-top "2rem"}]
+
+    "scroll-px-8"
+    [".scroll-px-8" {:scroll-padding-left "2rem"
+                     :scroll-padding-right "2rem"}]
+
     "touch-auto"
     [".touch-auto" {:touch-action "auto"}]
 

--- a/lib/girouette/test/girouette/tw/interactivity_test.cljc
+++ b/lib/girouette/test/girouette/tw/interactivity_test.cljc
@@ -9,6 +9,9 @@
     "appearance-none"
     [".appearance-none" {:appearance "none"}]
 
+    "cursor-help"
+    [".cursor-help" {:cursor "help"}]
+
     "cursor-wait"
     [".cursor-wait" {:cursor "wait"}]
 

--- a/lib/girouette/test/girouette/tw/interactivity_test.cljc
+++ b/lib/girouette/test/girouette/tw/interactivity_test.cljc
@@ -41,4 +41,10 @@
     [".scroll-auto" {:scroll-behavior "auto"}]
 
     "scroll-smooth"
-    [".scroll-smooth" {:scroll-behavior "smooth"}]))
+    [".scroll-smooth" {:scroll-behavior "smooth"}]
+
+    "will-change-auto"
+    [".will-change-auto" {:will-change "auto"}]
+
+    "will-change-scroll"
+    [".will-change-scroll" {:will-change "scroll-position"}]))

--- a/lib/girouette/test/girouette/tw/layout_test.cljc
+++ b/lib/girouette/test/girouette/tw/layout_test.cljc
@@ -37,6 +37,12 @@
     "inline-table"
     [".inline-table" {:display "inline-table"}]
 
+    "isolate"
+    [".isolate" {:isolation "isolate"}]
+
+    "isolation-auto"
+    [".isolation-auto" {:isolation "auto"}]
+
     "list-item"
     [".list-item" {:display "list-item"}]
 

--- a/lib/girouette/test/girouette/tw/layout_test.cljc
+++ b/lib/girouette/test/girouette/tw/layout_test.cljc
@@ -22,6 +22,12 @@
     "box-content"
     [".box-content" {:box-sizing "content-box"}]
 
+    "box-decoration-clone"
+    [".box-decoration-clone" {:box-decoration-break "clone"}]
+
+    "box-decoration-slice"
+    [".box-decoration-slice" {:box-decoration-break "slice"}]
+
     "flex"
     [".flex" {:display "flex"}]
 

--- a/lib/girouette/test/girouette/tw/layout_test.cljc
+++ b/lib/girouette/test/girouette/tw/layout_test.cljc
@@ -6,6 +6,18 @@
   (are [class-name expected-garden]
     (= expected-garden (class-name->garden class-name))
 
+    "aspect-auto"
+    [".aspect-auto" {:aspect-ratio "auto"}]
+
+    "aspect-square"
+    [".aspect-square" {:aspect-ratio "1 / 1"}]
+
+    "aspect-video"
+    [".aspect-video" {:aspect-ratio "16 / 9"}]
+
+    "aspect-23/57"
+    [".aspect-23\\/57" {:aspect-ratio "23 / 57"}]
+
     "container"
     [".container" {:width "100%"}]
 

--- a/lib/girouette/test/girouette/tw/layout_test.cljc
+++ b/lib/girouette/test/girouette/tw/layout_test.cljc
@@ -18,6 +18,12 @@
     "aspect-23/57"
     [".aspect-23\\/57" {:aspect-ratio "23 / 57"}]
 
+    "break-before-auto"
+    [".break-before-auto" {:break-before "auto"}]
+
+    "break-before-page"
+    [".break-before-page" {:break-before "page"}]
+
     "columns-auto"
     [".columns-auto" {:columns "auto"}]
 

--- a/lib/girouette/test/girouette/tw/layout_test.cljc
+++ b/lib/girouette/test/girouette/tw/layout_test.cljc
@@ -34,6 +34,9 @@
     "hidden"
     [".hidden" {:display "none"}]
 
+    "inline-table"
+    [".inline-table" {:display "inline-table"}]
+
     "object-left-top"
     [".object-left-top" {:object-position "left top"}]
 

--- a/lib/girouette/test/girouette/tw/layout_test.cljc
+++ b/lib/girouette/test/girouette/tw/layout_test.cljc
@@ -18,6 +18,15 @@
     "aspect-23/57"
     [".aspect-23\\/57" {:aspect-ratio "23 / 57"}]
 
+    "columns-auto"
+    [".columns-auto" {:columns "auto"}]
+
+    "columns-4"
+    [".columns-4" {:columns 4}]
+
+    "columns-2xl"
+    [".columns-2xl" {:columns "42rem"}]
+
     "container"
     [".container" {:width "100%"}]
 

--- a/lib/girouette/test/girouette/tw/layout_test.cljc
+++ b/lib/girouette/test/girouette/tw/layout_test.cljc
@@ -37,6 +37,9 @@
     "inline-table"
     [".inline-table" {:display "inline-table"}]
 
+    "list-item"
+    [".list-item" {:display "list-item"}]
+
     "object-left-top"
     [".object-left-top" {:object-position "left top"}]
 

--- a/lib/girouette/test/girouette/tw/layout_test.cljc
+++ b/lib/girouette/test/girouette/tw/layout_test.cljc
@@ -85,6 +85,12 @@
     "overflow-x-auto"
     [".overflow-x-auto" {:overflow-x "auto"}]
 
+    "overflow-x-clip"
+    [".overflow-x-clip" {:overflow-x "clip"}]
+
+    "overflow-clip"
+    [".overflow-clip" {:overflow "clip"}]
+
     "overflow-hidden"
     [".overflow-hidden" {:overflow "hidden"}]
 

--- a/lib/girouette/test/girouette/tw/sizing_test.cljc
+++ b/lib/girouette/test/girouette/tw/sizing_test.cljc
@@ -70,4 +70,10 @@
     [".max-w-screen-sm" {:max-width "640px"}]
 
     "max-h-64"
-    [".max-h-64" {:max-height "16rem"}]))
+    [".max-h-64" {:max-height "16rem"}]
+
+    "max-w-fit"
+    [".max-w-fit" {:max-width "fit-content"}]
+
+    "h-fit"
+    [".h-fit" {:height "fit-content"}]))

--- a/lib/girouette/test/girouette/tw/typography_test.cljc
+++ b/lib/girouette/test/girouette/tw/typography_test.cljc
@@ -16,6 +16,24 @@
     "decoration-#abcdef"
     [".decoration-\\#abcdef" {:text-decoration-color "#abcdef"}]
 
+    "decoration-wavy"
+    [".decoration-wavy" {:text-decoration-style "wavy"}]
+
+    "decoration-auto"
+    [".decoration-auto" {:text-decoration-thickness "auto"}]
+
+    "decoration-from-font"
+    [".decoration-from-font" {:text-decoration-thickness "from-font"}]
+
+    "decoration-3"
+    [".decoration-3" {:text-decoration-thickness "3px"}]
+
+    "decoration-1rem"
+    [".decoration-1rem" {:text-decoration-thickness "1rem"}]
+
+    "decoration-1/5"
+    [".decoration-1\\/5" {:text-decoration-thickness "20%"}]
+
     "font-sans"
     [".font-sans" {:font-family "ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, \"Segoe UI\", Roboto, \"Helvetica Neue\", Arial, \"Noto Sans\", sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Segoe UI Symbol\", \"Noto Color Emoji\""}]
 
@@ -152,4 +170,16 @@
     [".text-opacity-5" {:--gi-text-opacity 0.05}]
 
     "text-opacity-100"
-    [".text-opacity-100" {:--gi-text-opacity 1}]))
+    [".text-opacity-100" {:--gi-text-opacity 1}]
+
+    "underline-auto"
+    [".underline-auto" {:text-underline-offset "auto"}]
+
+    "underline-3"
+    [".underline-3" {:text-underline-offset "3px"}]
+
+    "underline-1rem"
+    [".underline-1rem" {:text-underline-offset "1rem"}]
+
+    "underline-1/5"
+    [".underline-1\\/5" {:text-underline-offset "20%"}]))

--- a/lib/girouette/test/girouette/tw/typography_test.cljc
+++ b/lib/girouette/test/girouette/tw/typography_test.cljc
@@ -37,6 +37,15 @@
     "font-thin"
     [".font-thin" {:font-weight 100}]
 
+    "indent-0"
+    [".indent-0" {:text-indent "0px"}]
+
+    "indent-1"
+    [".indent-1" {:text-indent "0.25rem"}]
+
+    "indent-2em"
+    [".indent-2em" {:text-indent "2em"}]
+
     "tracking-wide"
     [".tracking-wide" {:letter-spacing (str 0.025 "em")}]
 

--- a/lib/girouette/test/girouette/tw/typography_test.cljc
+++ b/lib/girouette/test/girouette/tw/typography_test.cljc
@@ -7,6 +7,21 @@
   (are [class-name expected-garden]
     (= expected-garden (class-name->garden class-name))
 
+    "content-['foo']"
+    [".content-\\[\\'foo\\'\\]" {:content "\"foo\""}]
+
+    "content-['foo\\'s']"
+    [".content-\\[\\'foo\\\\\\'s\\'\\]" {:content "\"foo's\""}]
+
+    "content-['foo_bar']"
+    [".content-\\[\\'foo_bar\\'\\]" {:content "\"foo bar\""}]
+
+    "content-['foo\\_bar']"
+    [".content-\\[\\'foo\\\\_bar\\'\\]" {:content "\"foo_bar\""}]
+
+    "content-[attr(foo)]"
+    [".content-\\[attr\\(foo\\)\\]" {:content "attr(foo)"}]
+
     "decoration-orange-100"
     [".decoration-orange-100" {:text-decoration-color "#ffedd5"}]
 

--- a/lib/girouette/test/girouette/tw/typography_test.cljc
+++ b/lib/girouette/test/girouette/tw/typography_test.cljc
@@ -131,6 +131,10 @@
     [".placeholder-green-300-50" [placeholder-pseudo-element
                                   {:color "#86efac7f"}]]
 
+    "placeholder-green-300/50"
+    [".placeholder-green-300\\/50" [placeholder-pseudo-element
+                                    {:color "#86efac7f"}]]
+
     "placeholder-opacity-20"
     [".placeholder-opacity-20" {:--gi-placeholder-opacity 0.2}]
 

--- a/lib/girouette/test/girouette/tw/typography_test.cljc
+++ b/lib/girouette/test/girouette/tw/typography_test.cljc
@@ -96,6 +96,9 @@
     [".text-black" {:--gi-text-opacity 1
                     :color "rgba(0,0,0,var(--gi-text-opacity))"}]
 
+    "text-clip"
+    [".text-clip" {:text-overflow "clip"}]
+
     "text-current"
     [".text-current" {:color "currentColor"}]
 

--- a/lib/girouette/test/girouette/tw/typography_test.cljc
+++ b/lib/girouette/test/girouette/tw/typography_test.cljc
@@ -7,6 +7,15 @@
   (are [class-name expected-garden]
     (= expected-garden (class-name->garden class-name))
 
+    "decoration-orange-100"
+    [".decoration-orange-100" {:text-decoration-color "#ffedd5"}]
+
+    "decoration-inherit"
+    [".decoration-inherit" {:text-decoration-color "inherit"}]
+
+    "decoration-#abcdef"
+    [".decoration-\\#abcdef" {:text-decoration-color "#abcdef"}]
+
     "font-sans"
     [".font-sans" {:font-family "ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, \"Segoe UI\", Roboto, \"Helvetica Neue\", Arial, \"Noto Sans\", sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Segoe UI Symbol\", \"Noto Color Emoji\""}]
 

--- a/lib/girouette/test/girouette/tw/typography_test.cljc
+++ b/lib/girouette/test/girouette/tw/typography_test.cljc
@@ -31,6 +31,9 @@
     [".antialiased" {:-webkit-font-smoothing "antialiased"
                      :-moz-osx-font-smoothing "grayscale"}]
 
+    "align-sub"
+    [".align-sub" {:vertical-align "sub"}]
+
     "italic"
     [".italic" {:font-style "italic"}]
 


### PR DESCRIPTION
As discussed in #79, Tailwind has added a number of features now.

<strike>This PR is still in-progress; just putting it up here for visibility and to facilitate discussion on which features are desirable, if there's a better way, etc.</strike>

Based on Tailwind's [CHANGELOG](https://github.com/tailwindlabs/tailwindcss/blob/master/CHANGELOG.md#202---2020-12-11), I see the following tasks to accomplish:

 - [X] cursor-help
 - [x] filter
 - [x] backdrop-filter
 - [X] list-item
 - [X] inline-table
 - [X] isolation
 - [X] box-decoration-berak
 - [X] mix-blend-mode
 - [X] background-blend-mode
 - [X] background-origin
 - [X] rename lightBlue to sky
 - [X] support other variants for group-
 - [X] add peer-* variants
 - [x] shortcut syntax for opacity (already supported in girouette, as `-N` instead of `/N`)
 - [x] content utilities
 - [x] per-side border colours
 - [x] self-baseline utility
 - [x] aspect-ratio
 - [x] accent-color
 - [x] scroll-behavior
 - [x] will-change
 - [x] text-indent
 - [x] column
 - [x] border-hidden
 - [x] align-sub, align-super
 - [x] break-before, break-inside, break-after
 - [x] file variant for file-selector-button
 - [x] touch-action
 - [x] overflow-clip, overflow-x-clip, overflow-y-clip
 - [x] [open] variant
 - [x] scroll-snap
 - [x] border-x border-y width & color
 - [x] rename overflow-clip to text-clip **BREAKING**
 - [x] rename overflow-ellipsis to text-ellipsis
 - [x] flex-basis
 - [x] fit-content for min/max-width/height
 - [x] min/max-content for min/max-height
 - [x] grow- shink- utilities
 - [x] text-decoration-color
 - [x] outline-style, outline-color, outline-width, outline-offset
 - [x] placeholder
 - [x] portrait and landscape variants
 - [x] text-decoration-style, -thickness, -offset
 - [x] ::before & ::after 
 - [ ] arbitrary values (e.g. `m-[calc(40%+10vh)]`)
 - [x] arbitrary properties (e.g. `hover:[mask-type:alpha]`)


