### PR TITLE
Fix invalid CSS color definition

### DIFF
--- a/lib/girouette/src/girouette/tw/effect.cljc
+++ b/lib/girouette/src/girouette/tw/effect.cljc
@@ -40,17 +40,17 @@
     :garden  (fn [{data :component-data}]
                (let [{:keys [box-shadow-value]} (into {} data)
                      [shadows-params shadow-color] (case box-shadow-value
-                                                     "sm" [["0 1px 2px 0"] "rgba(0,0,0/0.05)"]
+                                                     "sm" [["0 1px 2px 0"] "rgba(0,0,0,0.05)"]
                                                      nil [["0 1px 3px 0"
-                                                           "0 1px 2px -1px"] "rgba(0,0,0/0.1)"]
+                                                           "0 1px 2px -1px"] "rgba(0,0,0,0.1)"]
                                                      "md" [["0 4px 6px -1px"
-                                                            "0 2px 4px -2px"] "rgba(0,0,0/0.1)"]
+                                                            "0 2px 4px -2px"] "rgba(0,0,0,0.1)"]
                                                      "lg" [["0 10px 15px -3px"
-                                                            "0 4px 6px -4px"] "rgba(0,0,0/0.1)"]
+                                                            "0 4px 6px -4px"] "rgba(0,0,0,0.1)"]
                                                      "xl" [["0 20px 25px -5px"
-                                                            "0 8px 10px -6px"] "rgba(0,0,0/0.1)"]
-                                                     "2xl" [["0 25px 50px -12px"] "rgba(0,0,0/0.25)"]
-                                                     "inner" [["inset 0 2px 4px 0"] "rgba(0,0,0/0.05)"]
+                                                            "0 8px 10px -6px"] "rgba(0,0,0,0.1)"]
+                                                     "2xl" [["0 25px 50px -12px"] "rgba(0,0,0,0.25)"]
+                                                     "inner" [["inset 0 2px 4px 0"] "rgba(0,0,0,0.05)"]
                                                      "none" [["0 0"] "#0000"])]
                  {:--gi-shadow         (->> shadows-params
                                             (map (fn [shadow-params]


### PR DESCRIPTION
The color value specified in `box-shadow` rule is invalid and have no effect.

Ref: https://developer.mozilla.org/en-US/docs/Web/CSS/color_value#rgb_color_model