### PR TITLE
✨ Support for using `px` as optional number unit

### DIFF
--- a/lib/girouette/src/girouette/tw/background.cljc
+++ b/lib/girouette/src/girouette/tw/background.cljc
@@ -1,6 +1,6 @@
 (ns ^:no-doc girouette.tw.background
   (:require [clojure.string :as str]
-            [girouette.tw.common :refer [value-unit->css div-100 div-4 mul-100]]
+            [girouette.tw.common :as common :refer [value-unit->css div-100 div-4 mul-100]]
             [girouette.tw.color :refer [as-transparent color->css]]))
 
 (def components
@@ -94,8 +94,7 @@
                 {:background-size (first data)}
                 (let [[x y] data
                       options {:zero-unit nil
-                               :number {:unit "rem"
-                                        :value-fn div-4}
+                               :number (common/default-number-value-option)
                                :fraction {:unit "%"
                                           :value-fn mul-100}}]
                   {:background-size [[(value-unit->css x options)

--- a/lib/girouette/src/girouette/tw/common.cljc
+++ b/lib/girouette/src/girouette/tw/common.cljc
@@ -52,6 +52,25 @@
 (defn ratio-str [[x y]] (str x " / " y))
 
 
+;; This can be changed by passing another value in `make-api`
+(def ^:dynamic *default-number-unit* "rem")
+
+
+(defn default-number-value-fn
+  "Takes a tailwind number value and converts it as per the default unit.
+  Eg. p-1 turns into `padding: 0.25rem` or `padding: 4px` based on default unit."
+  [x]
+  (case *default-number-unit*
+    "rem" (div-4 x)
+    "px" (* 4 x)))
+
+
+(defn default-number-value-option []
+  "Configuration for how a default tailwind number unit gets converted to a css value."
+  {:unit *default-number-unit*
+   :value-fn default-number-value-fn})
+
+
 (defn read-number
   "Converts the input into a number.
    Accepts the formats [:integer \"1\"], [:number \"1\"] or \"1\".

--- a/lib/girouette/src/girouette/tw/default_api.cljc
+++ b/lib/girouette/src/girouette/tw/default_api.cljc
@@ -60,6 +60,15 @@
   (def tw-v3-parser parser)
   (def tw-v3-class-name->garden class-name->garden))
 
+;; The API built using the Tailwind v3 components but using "px" instead of "rem" for default number value units
+(let [{:keys [parser class-name->garden]} (-> all-tw-components
+                                              (version/filter-components-by-version [:tw 3])
+                                              (gtw/make-api {:color-map color/tw-v3-unified-colors-extended
+                                                             :font-family-map typography/tw-v2-font-family-map
+                                                             :default-number-unit "px"}))]
+  (def tw-v3-px-parser parser)
+  (def tw-v3-px-class-name->garden class-name->garden))
+
 
 ;; Feel free to fork the snippet above and add your own components,
 ;; as that's what Girouette was made for: customization.

--- a/lib/girouette/src/girouette/tw/flexbox.cljc
+++ b/lib/girouette/src/girouette/tw/flexbox.cljc
@@ -1,5 +1,5 @@
 (ns ^:no-doc girouette.tw.flexbox
-  (:require [girouette.tw.common :refer [value-unit->css div-4 mul-100]]))
+  (:require [girouette.tw.common :as common :refer [value-unit->css div-4 mul-100]]))
 
 (def components
   [{:id :flex-grow
@@ -39,8 +39,7 @@
                              (if (nil? flex-basis-value)
                                1
                                (value-unit->css flex-basis-value {:zero-unit "px"
-                                                                  :number {:unit "rem"
-                                                                           :value-fn div-4}
+                                                                  :number (common/default-number-value-option)
                                                                   :fraction {:unit "%"
                                                                              :value-fn mul-100}})))})}
 
@@ -74,8 +73,7 @@
                              grow-value (value-unit->css grow-data)
                              shrink-value (value-unit->css shrink-data)
                              basis-value (value-unit->css basis-data {:zero-unit nil
-                                                                      :number {:unit "rem"
-                                                                               :value-fn div-4}
+                                                                      :number (common/default-number-value-option)
                                                                       :fraction {:unit "%"
                                                                                  :value-fn mul-100}})]
                          (str grow-value " " shrink-value " " basis-value)))})}

--- a/lib/girouette/src/girouette/tw/grid.cljc
+++ b/lib/girouette/src/girouette/tw/grid.cljc
@@ -1,5 +1,5 @@
 (ns ^:no-doc girouette.tw.grid
-  (:require [girouette.tw.common :refer [value-unit->css div-4]]))
+  (:require [girouette.tw.common :as common :refer [value-unit->css div-4]]))
 
 (def components
   [{:id :grid-template-columns
@@ -154,5 +154,4 @@
                    "y" :row-gap
                    nil :gap} axis)
                  (value-unit->css gap-value {:zero-unit nil
-                                             :number {:unit "rem"
-                                                      :value-fn div-4}})}))}])
+                                             :number (common/default-number-value-option)})}))}])

--- a/lib/girouette/src/girouette/tw/interactivity.cljc
+++ b/lib/girouette/src/girouette/tw/interactivity.cljc
@@ -1,7 +1,7 @@
 (ns ^:no-doc girouette.tw.interactivity
   (:require
    [girouette.tw.color :refer [color->css]]
-   [girouette.tw.common :refer [value-unit->css div-4 mul-100]]))
+   [girouette.tw.common :as common :refer [value-unit->css div-4 mul-100]]))
 
 (def components
   [{:id :accent-color
@@ -110,8 +110,7 @@
                     value-css (value-unit->css scroll-margin-value
                                                {:signus signus
                                                 :zero-unit "px"
-                                                :number {:unit "rem"
-                                                         :value-fn div-4}})]
+                                                :number (common/default-number-value-option)})]
                 (into {}
                       (map (fn [prop]
                              [prop value-css]))
@@ -144,8 +143,7 @@
                     value-css (value-unit->css scroll-padding-value
                                                {:signus signus
                                                 :zero-unit "px"
-                                                :number {:unit "rem"
-                                                         :value-fn div-4}
+                                                :number (common/default-number-value-option)
                                                 :fraction {:unit "%"
                                                            :value-fn mul-100}})]
                 (into {}

--- a/lib/girouette/src/girouette/tw/layout.cljc
+++ b/lib/girouette/src/girouette/tw/layout.cljc
@@ -1,6 +1,6 @@
 (ns ^:no-doc girouette.tw.layout
   (:require [clojure.string :as str]
-            [girouette.tw.common :refer [value-unit->css breakpoint->pixels div-4 mul-100 ratio-str]]))
+            [girouette.tw.common :as common :refer [value-unit->css breakpoint->pixels div-4 mul-100 ratio-str]]))
 
 (def components
   [{:id :aspect-ratio
@@ -228,8 +228,7 @@
                     value-css (value-unit->css positioning-value
                                                {:signus signus
                                                 :zero-unit nil
-                                                :number {:unit "rem"
-                                                         :value-fn div-4}
+                                                :number (common/default-number-value-option)
                                                 :fraction {:unit "%"
                                                            :value-fn mul-100}})]
                 (into {}

--- a/lib/girouette/src/girouette/tw/sizing.cljc
+++ b/lib/girouette/src/girouette/tw/sizing.cljc
@@ -1,5 +1,5 @@
 (ns ^:no-doc girouette.tw.sizing
-  (:require [girouette.tw.common :refer [value-unit->css div-4 mul-100]]))
+  (:require [girouette.tw.common :as common :refer [value-unit->css div-4 mul-100]]))
 
 (def components
   [{:id :width
@@ -11,8 +11,7 @@
     :garden (fn [{[value-data] :component-data}]
               {:width (value-unit->css value-data
                                        {:zero-unit nil
-                                        :number {:unit "rem"
-                                                 :value-fn div-4}
+                                        :number (common/default-number-value-option)
                                         :fraction {:unit "%"
                                                    :value-fn mul-100}})})}
 
@@ -26,8 +25,7 @@
     :garden (fn [{[value-data] :component-data}]
               {:min-width (value-unit->css value-data
                                            {:zero-unit nil
-                                            :number {:unit "rem"
-                                                     :value-fn div-4}
+                                            :number (common/default-number-value-option)
                                             :fraction {:unit "%"
                                                        :value-fn mul-100}})})}
 
@@ -78,8 +76,7 @@
     :garden (fn [{[value-data] :component-data}]
               {:height (value-unit->css value-data
                                         {:zero-unit nil
-                                         :number {:unit "rem"
-                                                  :value-fn div-4}
+                                         :number (common/default-number-value-option)
                                          :fraction {:unit "%"
                                                     :value-fn mul-100}})})}
 
@@ -93,8 +90,7 @@
     :garden (fn [{[value-data] :component-data}]
               {:min-height (value-unit->css value-data
                                             {:zero-unit nil
-                                             :number {:unit "rem"
-                                                      :value-fn div-4}
+                                             :number (common/default-number-value-option)
                                              :fraction {:unit "%"
                                                         :value-fn mul-100}})})}
 
@@ -108,7 +104,6 @@
     :garden (fn [{[value-data] :component-data}]
               {:max-height (value-unit->css value-data
                                             {:zero-unit nil
-                                             :number {:unit "rem"
-                                                      :value-fn div-4}
+                                             :number (common/default-number-value-option)
                                              :fraction {:unit "%"
                                                         :value-fn mul-100}})})}])

--- a/lib/girouette/src/girouette/tw/spacing.cljc
+++ b/lib/girouette/src/girouette/tw/spacing.cljc
@@ -1,5 +1,5 @@
 (ns ^:no-doc girouette.tw.spacing
-  (:require [girouette.tw.common :refer [value-unit->css div-4 between-children-selector]]))
+  (:require [girouette.tw.common :as common :refer [value-unit->css div-4 between-children-selector]]))
 
 
 (def components
@@ -22,8 +22,7 @@
                                    nil))
                     value-css (value-unit->css padding-value {:signus signus
                                                               :zero-unit nil
-                                                              :number {:unit "rem"
-                                                                       :value-fn div-4}})]
+                                                              :number (common/default-number-value-option)})]
                 (if (nil? directions)
                   {:padding value-css}
                   (into {}
@@ -50,8 +49,7 @@
                                    nil))
                     value-css (value-unit->css margin-value {:signus signus
                                                              :zero-unit nil
-                                                             :number {:unit "rem"
-                                                                      :value-fn div-4}})]
+                                                             :number (common/default-number-value-option)})]
                 (if (nil? directions)
                   {:margin value-css}
                   (into {}
@@ -74,6 +72,5 @@
                                 ["y" true]  "bottom"} [axis (some? space-between-reverse)])
                     value-css (value-unit->css space-between-value {:signus signus
                                                                     :zero-unit nil
-                                                                    :number {:unit "rem"
-                                                                             :value-fn div-4}})]
+                                                                    :number (common/default-number-value-option)})]
                 [between-children-selector {(keyword (str "margin-" direction)) value-css}]))}])

--- a/lib/girouette/src/girouette/tw/transform.cljc
+++ b/lib/girouette/src/girouette/tw/transform.cljc
@@ -1,6 +1,6 @@
 (ns ^:no-doc girouette.tw.transform
   (:require [clojure.string :as str]
-            [girouette.tw.common :refer [value-unit->css div-100 div-4 mul-100]]))
+            [girouette.tw.common :as common :refer [value-unit->css div-100 div-4 mul-100]]))
 
 (def components
   [{:id :transform
@@ -97,8 +97,7 @@
                 {attribute (value-unit->css translate-value
                                             {:signus signus
                                              :zero-unit nil
-                                             :number {:unit "rem"
-                                                      :value-fn div-4}
+                                             :number (common/default-number-value-option)
                                              :fraction {:unit "%"
                                                         :value-fn mul-100}})}))}
 

--- a/lib/girouette/src/girouette/tw/typography.cljc
+++ b/lib/girouette/src/girouette/tw/typography.cljc
@@ -1,7 +1,7 @@
 (ns ^:no-doc girouette.tw.typography
   (:require [clojure.string :as str]
             [garden.selectors :refer [defpseudoelement]]
-            [girouette.tw.common :refer [matches-nothing value-unit->css div-4 mul-100 div-100]]
+            [girouette.tw.common :as common :refer [matches-nothing value-unit->css div-4 mul-100 div-100]]
             [girouette.tw.color :refer [color->css]]))
 
 
@@ -70,8 +70,7 @@
     "
     :garden (fn [{[value-data] :component-data}]
               {:font-size (value-unit->css value-data
-                                           {:number {:unit "rem"
-                                                     :value-fn div-4}
+                                           {:number (common/default-number-value-option)
                                             :fraction {:unit "%"
                                                        :value-fn mul-100}})})}
 
@@ -161,8 +160,7 @@
                                 "loose"   2} (second value-data))
                               (value-unit->css value-data
                                                {:zero-unit nil
-                                                :number {:unit "rem"
-                                                         :value-fn div-4}}))})}
+                                                :number (common/default-number-value-option)}))})}
 
 
    ;; This is an extra, not from Tailwind.
@@ -372,8 +370,7 @@
     :garden (fn [{[value-data] :component-data}]
               {:text-indent (value-unit->css value-data
                                              {:zero-unit "px"
-                                              :number {:unit "rem"
-                                                       :value-fn div-4}
+                                              :number (common/default-number-value-option)
                                               :fraction {:unit "%"
                                                          :value-fn mul-100}})})}
 


### PR DESCRIPTION
## Problem

Tailwind uses it's own number units. So for class name `p-1`, the number is `1`, and for `p-4` the number is `4`.

This tailwind unit typically equated to `1 unit = 0.25rem`. So `p-1` == `padding: 0.25rem` and `p-4 == padding: 1rem` (0.25*4)

But `1 rem` == font-size of the html element of the page. In unieque use cases like using `shadow-roots`, `rem`s no longer provide isolation, by being dependent on the host css styles.

## Use case

I want to develop chrome extensions and need to isolate a part of our code on the user page. To do this we are using a shadow root component.

So for example if I use the shadow-root on page A with  `html { font-size: 16px }` the value of `p-4 == 1rem == 16px` (the default for most browsers)
But on page B with `html { font-size: 18px }` the value of `p-4 == 1rem == 18px`

## Solution

To avoid this use case, we add support for `px` values such that optionally the tailwind unit can become `1 unit = 4px`. This is equivalent to `html { font-size: 16px }`, which is typically what browsers default to.

## Preview

```clojure
(let [{:keys [parser class-name->garden]} (-> all-tw-components
                                              (version/filter-components-by-version [:tw 3])
                                              (gtw/make-api {:color-map color/tw-v3-unified-colors-extended
                                                             :font-family-map typography/tw-v2-font-family-map
                                                             :default-number-unit "rem"}))]
  (class-name->garden "p-1"))
;; => [".p-1" {:padding "0.25rem"}]

(let [{:keys [parser class-name->garden]} (-> all-tw-components
                                              (version/filter-components-by-version [:tw 3])
                                              (gtw/make-api {:color-map color/tw-v3-unified-colors-extended
                                                             :font-family-map typography/tw-v2-font-family-map
                                                             :default-number-unit "px"}))]
  (class-name->garden "p-1"))
;; => [".p-1" {:padding "4px"}]
```


## Pending
- [ ] A lot of rules still uses hardcoded `rem` values like: `text-`, `font-size-`, `max-w-`, `columns-` `border-radius-`. These typically use the `xs` `md` `lg` etc. terminology. 
- [ ] Do we need separate tests for this?
- [ ] Updating readme
- [ ] Ideally make this more configurable so people can provide their own functions to determine how should a `value-unit` be transformed to `css`