### PR TITLE
Customization of length as number without a unit

### DIFF
--- a/lib/girouette/src/girouette/tw/background.cljc
+++ b/lib/girouette/src/girouette/tw/background.cljc
@@ -89,13 +89,13 @@
                                <'size-'> background-size-length <'-'> background-size-length)
     <background-size-length> = auto | number | length | length-unit | fraction | percentage
     "
-    :garden (fn [{data :component-data}]
+    :garden (fn [{data :component-data
+                  :keys [unitless-length-conversion]}]
               (if (= (count data) 1)
                 {:background-size (first data)}
                 (let [[x y] data
                       options {:zero-unit nil
-                               :number {:unit "rem"
-                                        :value-fn div-4}
+                               :number unitless-length-conversion
                                :fraction {:unit "%"
                                           :value-fn mul-100}}]
                   {:background-size [[(value-unit->css x options)

--- a/lib/girouette/src/girouette/tw/common.cljc
+++ b/lib/girouette/src/girouette/tw/common.cljc
@@ -46,6 +46,7 @@
 
 (defn div-4   [x] (/ x 4))
 (defn div-100 [x] (/ x 100))
+(defn mul-4   [x] (* x 4))
 (defn mul-100 [x] (* x 100))
 (defn mul-255 [x] (* x 255))
 (defn clamp-0-255 [x] (-> x (max 0) (min 255)))

--- a/lib/girouette/src/girouette/tw/core.cljc
+++ b/lib/girouette/src/girouette/tw/core.cljc
@@ -107,7 +107,11 @@
 
 (defn make-api
   "Creates an API based on a collection of Girouette components."
-  [components {:keys [color-map font-family-map]}]
+  [components {:keys [color-map
+                      font-family-map
+                      unitless-length-conversion]
+               :or {unitless-length-conversion {:unit "rem"
+                                                :value-fn common/div-4}}}]
   (let [components (util/into-one-vector components) ;; flatten the structure
         flattened-color-map (color/flatten-color-map color-map)
         grammar (assemble-grammar components {:color-map flattened-color-map
@@ -119,7 +123,8 @@
                             complement-before-rules-after-rules
                             assoc-ordering-level)
         predef-props {:read-color (partial color/read-color flattened-color-map)
-                      :font-family-map font-family-map}
+                      :font-family-map font-family-map
+                      :unitless-length-conversion unitless-length-conversion}
         class-name->garden (fn [class-name]
                              (let [parsed-data (insta/parse parser class-name)]
                                (when-not (insta/failure? parsed-data)

--- a/lib/girouette/src/girouette/tw/default_api.cljc
+++ b/lib/girouette/src/girouette/tw/default_api.cljc
@@ -56,7 +56,12 @@
 (let [{:keys [parser class-name->garden]} (-> all-tw-components
                                               (version/filter-components-by-version [:tw 3])
                                               (gtw/make-api {:color-map color/tw-v3-unified-colors-extended
-                                                             :font-family-map typography/tw-v2-font-family-map}))]
+                                                             :font-family-map typography/tw-v2-font-family-map
+                                                             ;; Customization of unitless-length conversion is possible.
+                                                             ;; e.g. "p-2" -> {:padding "8px"}
+                                                             #_#_
+                                                             :unitless-length-conversion {:unit "px"
+                                                                                          :value-fn common/mul-4}}))]
   (def tw-v3-parser parser)
   (def tw-v3-class-name->garden class-name->garden))
 

--- a/lib/girouette/src/girouette/tw/flexbox.cljc
+++ b/lib/girouette/src/girouette/tw/flexbox.cljc
@@ -34,13 +34,13 @@
     flex-basis = <'flex-'>? <'basis'> (<'-'> flex-basis-value)?
     flex-basis-value = number | length | length-unit | fraction | percentage | full-100% | auto
     "
-    :garden (fn [{data :component-data}]
+    :garden (fn [{data :component-data
+                  :keys [unitless-length-conversion]}]
               {:flex-basis (let [{:keys [flex-basis-value]} (into {} data)]
                              (if (nil? flex-basis-value)
                                1
                                (value-unit->css flex-basis-value {:zero-unit "px"
-                                                                  :number {:unit "rem"
-                                                                           :value-fn div-4}
+                                                                  :number unitless-length-conversion
                                                                   :fraction {:unit "%"
                                                                              :value-fn mul-100}})))})}
 
@@ -53,7 +53,8 @@
     flex-shorthand-2-args = flex-grow-value <'-'> (flex-shrink-value | flex-basis-value)
     flex-shorthand-3-args = flex-grow-value <'-'> flex-shrink-value <'-'> flex-basis-value
     "
-    :garden (fn [{[[shorthand-type & args]] :component-data}]
+    :garden (fn [{[[shorthand-type & args]] :component-data
+                  :keys [unitless-length-conversion]}]
               {:flex (case shorthand-type
                        :flex-shorthand-1-arg
                        (case (first args)
@@ -74,8 +75,7 @@
                              grow-value (value-unit->css grow-data)
                              shrink-value (value-unit->css shrink-data)
                              basis-value (value-unit->css basis-data {:zero-unit nil
-                                                                      :number {:unit "rem"
-                                                                               :value-fn div-4}
+                                                                      :number unitless-length-conversion
                                                                       :fraction {:unit "%"
                                                                                  :value-fn mul-100}})]
                          (str grow-value " " shrink-value " " basis-value)))})}

--- a/lib/girouette/src/girouette/tw/grid.cljc
+++ b/lib/girouette/src/girouette/tw/grid.cljc
@@ -148,11 +148,11 @@
     gap = <'gap-'> (axis <'-'>)? gap-value
     gap-value = number | length | length-unit | percentage
     "
-    :garden (fn [{data :component-data}]
+    :garden (fn [{data :component-data
+                  :keys [unitless-length-conversion]}]
               (let [{:keys [axis gap-value]} (into {} data)]
                 {({"x" :column-gap
                    "y" :row-gap
                    nil :gap} axis)
                  (value-unit->css gap-value {:zero-unit nil
-                                             :number {:unit "rem"
-                                                      :value-fn div-4}})}))}])
+                                             :number unitless-length-conversion})}))}])

--- a/lib/girouette/src/girouette/tw/interactivity.cljc
+++ b/lib/girouette/src/girouette/tw/interactivity.cljc
@@ -91,7 +91,7 @@
     scroll-margin = signus? <'scroll-m'> (direction | axis)? <'-'> scroll-margin-value
     scroll-margin-value = number | length | length-unit
     "
-    :garden (fn [{:keys [component-data]}]
+    :garden (fn [{:keys [component-data unitless-length-conversion]}]
               (let [{:keys [signus direction axis scroll-margin-value]} (into {} component-data)
                     directions (case direction
                                  "t" ["top"]
@@ -110,8 +110,7 @@
                     value-css (value-unit->css scroll-margin-value
                                                {:signus signus
                                                 :zero-unit "px"
-                                                :number {:unit "rem"
-                                                         :value-fn div-4}})]
+                                                :number unitless-length-conversion})]
                 (into {}
                       (map (fn [prop]
                              [prop value-css]))
@@ -124,7 +123,7 @@
     scroll-padding = signus? <'scroll-p'> (direction | axis)? <'-'> scroll-padding-value
     scroll-padding-value = number | length | length-unit | fraction | percentage
     "
-    :garden (fn [{:keys [component-data]}]
+    :garden (fn [{:keys [component-data unitless-length-conversion]}]
               (let [{:keys [signus direction axis scroll-padding-value]}
                     (into {} component-data)
                     directions (case direction
@@ -144,8 +143,7 @@
                     value-css (value-unit->css scroll-padding-value
                                                {:signus signus
                                                 :zero-unit "px"
-                                                :number {:unit "rem"
-                                                         :value-fn div-4}
+                                                :number unitless-length-conversion
                                                 :fraction {:unit "%"
                                                            :value-fn mul-100}})]
                 (into {}

--- a/lib/girouette/src/girouette/tw/layout.cljc
+++ b/lib/girouette/src/girouette/tw/layout.cljc
@@ -216,7 +216,7 @@
     positioning-mode = 'top' | 'right' | 'bottom' | 'left' | #'inset(-x|-y)?'
     positioning-value = number | length | length-unit | fraction | percentage | full-100% | auto
     "
-    :garden (fn [{component-data :component-data}]
+    :garden (fn [{:keys [component-data unitless-length-conversion]}]
               (let [{:keys [signus positioning-mode positioning-value]} (into {} component-data)
                     directions ({"inset" [:top :right :bottom :left]
                                  "inset-x" [:right :left]
@@ -228,8 +228,7 @@
                     value-css (value-unit->css positioning-value
                                                {:signus signus
                                                 :zero-unit nil
-                                                :number {:unit "rem"
-                                                         :value-fn div-4}
+                                                :number unitless-length-conversion
                                                 :fraction {:unit "%"
                                                            :value-fn mul-100}})]
                 (into {}

--- a/lib/girouette/src/girouette/tw/sizing.cljc
+++ b/lib/girouette/src/girouette/tw/sizing.cljc
@@ -8,11 +8,11 @@
     width = <'w-'> (number | length | length-unit | fraction | percentage | full-100% |
                     auto | screen-100vw | min-content | max-content | fit-content)
     "
-    :garden (fn [{[value-data] :component-data}]
+    :garden (fn [{[value-data] :component-data
+                  :keys [unitless-length-conversion]}]
               {:width (value-unit->css value-data
                                        {:zero-unit nil
-                                        :number {:unit "rem"
-                                                 :value-fn div-4}
+                                        :number unitless-length-conversion
                                         :fraction {:unit "%"
                                                    :value-fn mul-100}})})}
 
@@ -23,11 +23,11 @@
     min-width = <'min-w-'> (number | length | length-unit | fraction | percentage | full-100% |
                             auto | screen-100vw | min-content | max-content | fit-content)
     "
-    :garden (fn [{[value-data] :component-data}]
+    :garden (fn [{[value-data] :component-data
+                  :keys [unitless-length-conversion]}]
               {:min-width (value-unit->css value-data
                                            {:zero-unit nil
-                                            :number {:unit "rem"
-                                                     :value-fn div-4}
+                                            :number unitless-length-conversion
                                             :fraction {:unit "%"
                                                        :value-fn mul-100}})})}
 
@@ -41,7 +41,7 @@
     max-width-generic-size = number | length | length-unit | fraction | percentage | full-100% |
                              none | screen-100vw | min-content | max-content | fit-content
     "
-    :garden (fn [{:keys [component-data]}]
+    :garden (fn [{:keys [component-data unitless-length-conversion]}]
               (let [{:keys [max-width-fixed-size max-width-generic-size]} (into {} component-data)]
                 {:max-width (if (some? max-width-fixed-size)
                               ({"xs"  "20rem"
@@ -63,8 +63,7 @@
                                 "screen-2xl" "1536px"} max-width-fixed-size)
                               (value-unit->css max-width-generic-size
                                                {:zero-unit nil
-                                                :number    {:unit     "rem"
-                                                            :value-fn div-4}
+                                                :number    unitless-length-conversion
                                                 :fraction  {:unit     "%"
                                                             :value-fn mul-100}}))}))}
 
@@ -75,11 +74,11 @@
     height = <'h-'> (number | length | length-unit | fraction | percentage | full-100% |
                      auto | screen-100vh | min-content | max-content | fit-content)
     "
-    :garden (fn [{[value-data] :component-data}]
+    :garden (fn [{[value-data] :component-data
+                  :keys [unitless-length-conversion]}]
               {:height (value-unit->css value-data
                                         {:zero-unit nil
-                                         :number {:unit "rem"
-                                                  :value-fn div-4}
+                                         :number unitless-length-conversion
                                          :fraction {:unit "%"
                                                     :value-fn mul-100}})})}
 
@@ -90,11 +89,11 @@
     min-height = <'min-h-'> (number | length | length-unit | fraction | percentage | full-100% |
                              auto | screen-100vh | min-content | max-content | fit-content)
     "
-    :garden (fn [{[value-data] :component-data}]
+    :garden (fn [{[value-data] :component-data
+                  :keys [unitless-length-conversion]}]
               {:min-height (value-unit->css value-data
                                             {:zero-unit nil
-                                             :number {:unit "rem"
-                                                      :value-fn div-4}
+                                             :number unitless-length-conversion
                                              :fraction {:unit "%"
                                                         :value-fn mul-100}})})}
 
@@ -105,10 +104,10 @@
     max-height = <'max-h-'> (number | length | length-unit | fraction | percentage | full-100% |
                              none | screen-100vh | min-content | max-content | fit-content)
     "
-    :garden (fn [{[value-data] :component-data}]
+    :garden (fn [{[value-data] :component-data
+                  :keys [unitless-length-conversion]}]
               {:max-height (value-unit->css value-data
                                             {:zero-unit nil
-                                             :number {:unit "rem"
-                                                      :value-fn div-4}
+                                             :number unitless-length-conversion
                                              :fraction {:unit "%"
                                                         :value-fn mul-100}})})}])

--- a/lib/girouette/src/girouette/tw/spacing.cljc
+++ b/lib/girouette/src/girouette/tw/spacing.cljc
@@ -9,7 +9,7 @@
     padding = signus? <'p'> (direction | axis)? <'-'> padding-value
     padding-value = number | length | length-unit
     "
-    :garden (fn [{component-data :component-data}]
+    :garden (fn [{:keys [component-data unitless-length-conversion]}]
               (let [{:keys [signus direction axis padding-value]} (into {} component-data)
                     directions (case direction
                                  "t" ["top"]
@@ -22,8 +22,7 @@
                                    nil))
                     value-css (value-unit->css padding-value {:signus signus
                                                               :zero-unit nil
-                                                              :number {:unit "rem"
-                                                                       :value-fn div-4}})]
+                                                              :number unitless-length-conversion})]
                 (if (nil? directions)
                   {:padding value-css}
                   (into {}
@@ -37,7 +36,7 @@
     margin = signus? <'m'> (direction | axis)? <'-'> margin-value
     margin-value = number | length | length-unit | auto
     "
-    :garden (fn [{component-data :component-data}]
+    :garden (fn [{:keys [component-data unitless-length-conversion]}]
               (let [{:keys [signus direction axis margin-value]} (into {} component-data)
                     directions (case direction
                                  "t" ["top"]
@@ -50,8 +49,7 @@
                                    nil))
                     value-css (value-unit->css margin-value {:signus signus
                                                              :zero-unit nil
-                                                             :number {:unit "rem"
-                                                                      :value-fn div-4}})]
+                                                             :number unitless-length-conversion})]
                 (if (nil? directions)
                   {:margin value-css}
                   (into {}
@@ -66,7 +64,7 @@
     space-between-value = number | length | length-unit
     space-between-reverse = 'reverse'
     "
-    :garden (fn [{component-data :component-data}]
+    :garden (fn [{:keys [component-data unitless-length-conversion]}]
               (let [{:keys [signus axis space-between-value space-between-reverse]} (into {} component-data)
                     direction ({["x" false] "left"
                                 ["x" true]  "right"
@@ -74,6 +72,5 @@
                                 ["y" true]  "bottom"} [axis (some? space-between-reverse)])
                     value-css (value-unit->css space-between-value {:signus signus
                                                                     :zero-unit nil
-                                                                    :number {:unit "rem"
-                                                                             :value-fn div-4}})]
+                                                                    :number unitless-length-conversion})]
                 [between-children-selector {(keyword (str "margin-" direction)) value-css}]))}])

--- a/lib/girouette/src/girouette/tw/transform.cljc
+++ b/lib/girouette/src/girouette/tw/transform.cljc
@@ -90,15 +90,15 @@
     translate = signus? <'translate-'> axis <'-'> translate-value
     translate-value = number | length | length-unit | fraction | percentage | full-100%
     "
-    :garden (fn [{data :component-data}]
+    :garden (fn [{data :component-data
+                  :keys [unitless-length-conversion]}]
               (let [{:keys [signus axis translate-value]} (into {} data)
                     attribute ({"x" :--gi-translate-x
                                 "y" :--gi-translate-y} axis)]
                 {attribute (value-unit->css translate-value
                                             {:signus signus
                                              :zero-unit nil
-                                             :number {:unit "rem"
-                                                      :value-fn div-4}
+                                             :number unitless-length-conversion
                                              :fraction {:unit "%"
                                                         :value-fn mul-100}})}))}
 

--- a/lib/girouette/src/girouette/tw/typography.cljc
+++ b/lib/girouette/src/girouette/tw/typography.cljc
@@ -68,10 +68,10 @@
     :rules "
     font-size-2 = <'font-size-'> (number | length | fraction | percentage)
     "
-    :garden (fn [{[value-data] :component-data}]
+    :garden (fn [{[value-data] :component-data
+                  :keys [unitless-length-conversion]}]
               {:font-size (value-unit->css value-data
-                                           {:number {:unit "rem"
-                                                     :value-fn div-4}
+                                           {:number unitless-length-conversion
                                             :fraction {:unit "%"
                                                        :value-fn mul-100}})})}
 
@@ -151,7 +151,8 @@
     line-height = <'leading-'> (line-height-size-name | number)
     line-height-size-name = 'none' | 'tight' | 'snug' | 'normal' | 'relaxed' | 'loose'
     "
-    :garden (fn [{[value-data] :component-data}]
+    :garden (fn [{[value-data] :component-data
+                  :keys [unitless-length-conversion]}]
               {:line-height (if (= (first value-data) :line-height-size-name)
                               ({"none"    1
                                 "tight"   1.25
@@ -161,8 +162,7 @@
                                 "loose"   2} (second value-data))
                               (value-unit->css value-data
                                                {:zero-unit nil
-                                                :number {:unit "rem"
-                                                         :value-fn div-4}}))})}
+                                                :number unitless-length-conversion}))})}
 
 
    ;; This is an extra, not from Tailwind.
@@ -369,11 +369,11 @@
     :rules "
     text-indent = <'indent-'> (number | length | length-unit | fraction)
     "
-    :garden (fn [{[value-data] :component-data}]
+    :garden (fn [{[value-data] :component-data
+                  :keys [unitless-length-conversion]}]
               {:text-indent (value-unit->css value-data
                                              {:zero-unit "px"
-                                              :number {:unit "rem"
-                                                       :value-fn div-4}
+                                              :number unitless-length-conversion
                                               :fraction {:unit "%"
                                                          :value-fn mul-100}})})}
 


### PR DESCRIPTION
Adds customization of length when expressed as a non-zero number with no unit as prefix.

Initial implementation was made by @oxalorg in pull request #96. This commit is rewrite without using dynamic variables.