### PR TITLE
Factor media query min-width into rule-comparator

### DIFF
--- a/lib/girouette/test/girouette/garden/util_test.cljc
+++ b/lib/girouette/test/girouette/garden/util_test.cljc
@@ -44,4 +44,20 @@
 
     "md:grid-cols-1"
     "dark:text-white"
-    1))
+    1
+
+    "hover:bg-red-500"
+    "active:bg-blue-500"
+    -1
+
+    "active:hover:bg-red-500"
+    "active:bg-blue-500"
+    1
+
+    "disabled:bg-red-500"
+    "hover:bg-red-200"
+    -1
+
+    "focus:disabled:bg-red-500"
+    "hover:bg-red-200"
+    -1))

--- a/lib/girouette/test/girouette/garden/util_test.cljc
+++ b/lib/girouette/test/girouette/garden/util_test.cljc
@@ -2,7 +2,7 @@
   (:require [clojure.test :refer [deftest testing is are]]
             [girouette.tw.default-api :refer [tw-v3-class-name->garden]]
             [girouette.tw.common :refer [dot]]
-            [girouette.garden.util :refer [apply-class-rules]]))
+            [girouette.garden.util :refer [apply-class-rules rule-comparator]]))
 
 (deftest apply-class-rules-test
   (are [target-class-name gi-class-names expected-garden]
@@ -26,3 +26,22 @@
                                           :rules [[".my-class" {:padding "0.25rem"
                                                                 :margin "0.25rem"}]
                                                   [".my-class" [:&:hover {:padding "0.5rem"}]]]}})))
+
+(deftest rule-comparator-sorting-test
+  (are [rule1 rule2 comparison]
+      (= (rule-comparator
+           (tw-v3-class-name->garden rule1)
+           (tw-v3-class-name->garden rule2))
+         comparison)
+
+    "md:grid-cols-1"
+    "lg:grid-cols-1"
+    -1
+
+    "md:grid-cols-2"
+    "grid-cols-1"
+    1
+
+    "md:grid-cols-1"
+    "dark:text-white"
+    1))


### PR DESCRIPTION
In order for larger sizes to override smaller ones and thus allow examples like `grid grid-cols-3 md:grid-cols-4 lg:grid-cols-6` to work, the larger minimum sizes need to come later in the output file.